### PR TITLE
Xunit conversion

### DIFF
--- a/NModbus4.UnitTests/Data/DataStoreEventArgsFixture.cs
+++ b/NModbus4.UnitTests/Data/DataStoreEventArgsFixture.cs
@@ -1,36 +1,35 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using Modbus.Data;
+using Xunit;
 
 namespace Modbus.UnitTests.Data
 {
-    using System;
-    using NUnit.Framework;
-
-    [TestFixture]
     public class DataStoreEventArgsFixture
     {
-        [Test]
+        [Fact]
         public void CreateDataStoreEventArgs()
         {
             var eventArgs = DataStoreEventArgs.CreateDataStoreEventArgs(5, ModbusDataType.HoldingRegister,
                 new ushort[] {1, 2, 3});
-            Assert.AreEqual(ModbusDataType.HoldingRegister, eventArgs.ModbusDataType);
-            Assert.AreEqual(5, eventArgs.StartAddress);
-            Assert.AreEqual(new ushort[] {1, 2, 3}, eventArgs.Data.B.ToArray());
+            Assert.Equal(ModbusDataType.HoldingRegister, eventArgs.ModbusDataType);
+            Assert.Equal(5, eventArgs.StartAddress);
+            Assert.Equal(new ushort[] {1, 2, 3}, eventArgs.Data.B.ToArray());
         }
 
-        [Test, ExpectedException(typeof (ArgumentException))]
+        [Fact]
         public void CreateDataStoreEventArgs_InvalidType()
         {
-            var eventArgs = DataStoreEventArgs.CreateDataStoreEventArgs(5, ModbusDataType.HoldingRegister,
-                new int[] {1, 2, 3});
+            Assert.Throws<ArgumentException>(() => DataStoreEventArgs.CreateDataStoreEventArgs(5, ModbusDataType.HoldingRegister,
+                new int[] {1, 2, 3}));
         }
 
-        [Test, ExpectedException(typeof (ArgumentNullException))]
+        [Fact]
         public void CreateDataStoreEventArgs_DataNull()
         {
-            var eventArgs = DataStoreEventArgs.CreateDataStoreEventArgs(5, ModbusDataType.HoldingRegister,
-                default(ushort[]));
+            Assert.Throws<ArgumentNullException>(() =>
+                DataStoreEventArgs.CreateDataStoreEventArgs(5, ModbusDataType.HoldingRegister,
+                    default(ushort[])));
         }
     }
 }

--- a/NModbus4.UnitTests/Data/DataStoreFixture.cs
+++ b/NModbus4.UnitTests/Data/DataStoreFixture.cs
@@ -2,83 +2,82 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Modbus.Data;
+using Xunit;
 
 namespace Modbus.UnitTests.Data
 {
-    using NUnit.Framework;
-
-    [TestFixture]
     public class DataStoreFixture
     {
-        [Test]
+        [Fact]
         public void ReadData()
         {
             ModbusDataCollection<ushort> slaveCol = new ModbusDataCollection<ushort>(0, 1, 2, 3, 4, 5, 6);
             RegisterCollection result = DataStore.ReadData<RegisterCollection, ushort>(new DataStore(), slaveCol, 1, 3,
                 new object());
-            Assert.AreEqual(new ushort[] {1, 2, 3}, result.ToArray());
+            Assert.Equal(new ushort[] {1, 2, 3}, result.ToArray());
         }
 
-        [Test, ExpectedException(typeof (InvalidModbusRequestException))]
+        [Fact]
         public void ReadDataStartAddressTooLarge()
         {
-            DataStore.ReadData<DiscreteCollection, bool>(new DataStore(), new ModbusDataCollection<bool>(), 3, 2,
-                new object());
+            Assert.Throws<InvalidModbusRequestException>(() =>
+                DataStore.ReadData<DiscreteCollection, bool>(new DataStore(), new ModbusDataCollection<bool>(), 3, 2,
+                    new object()));
         }
 
-        [Test, ExpectedException(typeof (InvalidModbusRequestException))]
+        [Fact]
         public void ReadDataCountTooLarge()
         {
-            DataStore.ReadData<DiscreteCollection, bool>(new DataStore(),
-                new ModbusDataCollection<bool>(true, false, true, true), 1, 5, new object());
+            Assert.Throws<InvalidModbusRequestException>(() => DataStore.ReadData<DiscreteCollection, bool>(new DataStore(),
+                new ModbusDataCollection<bool>(true, false, true, true), 1, 5, new object()));
         }
 
-        [Test]
+        [Fact]
         public void ReadDataStartAddressZero()
         {
             DataStore.ReadData<DiscreteCollection, bool>(new DataStore(),
                 new ModbusDataCollection<bool>(true, false, true, true, true, true), 0, 5, new object());
         }
 
-        [Test]
+        [Fact]
         public void WriteDataSingle()
         {
             ModbusDataCollection<bool> destination = new ModbusDataCollection<bool>(true, true);
             DiscreteCollection newValues = new DiscreteCollection(false);
             DataStore.WriteData(new DataStore(), newValues, destination, 0, new object());
-            Assert.AreEqual(false, destination[1]);
+            Assert.Equal(false, destination[1]);
         }
 
-        [Test]
+        [Fact]
         public void WriteDataMultiple()
         {
             ModbusDataCollection<bool> destination = new ModbusDataCollection<bool>(false, false, false, false, false,
                 false, true);
             DiscreteCollection newValues = new DiscreteCollection(true, true, true, true);
             DataStore.WriteData(new DataStore(), newValues, destination, 0, new object());
-            Assert.AreEqual(new bool[] {false, true, true, true, true, false, false, true}, destination.ToArray());
+            Assert.Equal(new bool[] {false, true, true, true, true, false, false, true}, destination.ToArray());
         }
 
-        [Test, ExpectedException(typeof(InvalidModbusRequestException))]
+        [Fact]
         public void WriteDataTooLarge()
         {
             ModbusDataCollection<bool> slaveCol = new ModbusDataCollection<bool>(true);
             DiscreteCollection newValues = new DiscreteCollection(false, false);
-            DataStore.WriteData(new DataStore(), newValues, slaveCol, 1, new object());
+            Assert.Throws<InvalidModbusRequestException>(() => DataStore.WriteData(new DataStore(), newValues, slaveCol, 1, new object()));
         }
 
-        [Test]
+        [Fact]
         public void WriteDataStartAddressZero()
         {
             DataStore.WriteData(new DataStore(), new DiscreteCollection(false),
                 new ModbusDataCollection<bool>(true, true), 0, new object());
         }
 
-        [Test, ExpectedException(typeof(InvalidModbusRequestException))]
+        [Fact]
         public void WriteDataStartAddressTooLarge()
         {
-            DataStore.WriteData(new DataStore(), new DiscreteCollection(true), new ModbusDataCollection<bool>(true), 2,
-                new object());
+            Assert.Throws<InvalidModbusRequestException>(() => DataStore.WriteData(new DataStore(), new DiscreteCollection(true), new ModbusDataCollection<bool>(true), 2,
+                new object()));
         }
 
         /// <summary>
@@ -87,22 +86,22 @@ namespace Modbus.UnitTests.Data
         ///     So reading Modbus address 0 should get you array index 1 in the DataStore.
         ///     This implies that the DataStore array index 0 can never be used.
         /// </summary>
-        [Test]
+        [Fact]
         public void TestReadMapping()
         {
             DataStore dataStore = DataStoreFactory.CreateDefaultDataStore();
             dataStore.HoldingRegisters.Insert(1, 45);
             dataStore.HoldingRegisters.Insert(2, 42);
 
-            Assert.AreEqual(45,
+            Assert.Equal(45,
                 DataStore.ReadData<RegisterCollection, ushort>(dataStore, dataStore.HoldingRegisters, 0, 1, new object())
                     [0]);
-            Assert.AreEqual(42,
+            Assert.Equal(42,
                 DataStore.ReadData<RegisterCollection, ushort>(dataStore, dataStore.HoldingRegisters, 1, 1, new object())
                     [0]);
         }
 
-        [Test]
+        [Fact]
         public void DataStoreReadFromEvent_ReadHoldingRegisters()
         {
             DataStore dataStore = DataStoreFactory.CreateTestDataStore();
@@ -113,19 +112,19 @@ namespace Modbus.UnitTests.Data
             dataStore.DataStoreReadFrom += (obj, e) =>
             {
                 readFromEventFired = true;
-                Assert.AreEqual(3, e.StartAddress);
-                Assert.AreEqual(new ushort[] {4, 5, 6}, e.Data.B.ToArray());
-                Assert.AreEqual(ModbusDataType.HoldingRegister, e.ModbusDataType);
+                Assert.Equal(3, e.StartAddress);
+                Assert.Equal(new ushort[] {4, 5, 6}, e.Data.B.ToArray());
+                Assert.Equal(ModbusDataType.HoldingRegister, e.ModbusDataType);
             };
 
             dataStore.DataStoreWrittenTo += (obj, e) => writtenToEventFired = true;
 
             DataStore.ReadData<RegisterCollection, ushort>(dataStore, dataStore.HoldingRegisters, 3, 3, new object());
-            Assert.IsTrue(readFromEventFired);
-            Assert.IsFalse(writtenToEventFired);
+            Assert.True(readFromEventFired);
+            Assert.False(writtenToEventFired);
         }
 
-        [Test]
+        [Fact]
         public void DataStoreReadFromEvent_ReadInputRegisters()
         {
             DataStore dataStore = DataStoreFactory.CreateTestDataStore();
@@ -136,19 +135,19 @@ namespace Modbus.UnitTests.Data
             dataStore.DataStoreReadFrom += (obj, e) =>
             {
                 readFromEventFired = true;
-                Assert.AreEqual(4, e.StartAddress);
-                Assert.AreEqual(new ushort[] {}, e.Data.B.ToArray());
-                Assert.AreEqual(ModbusDataType.InputRegister, e.ModbusDataType);
+                Assert.Equal(4, e.StartAddress);
+                Assert.Equal(new ushort[] {}, e.Data.B.ToArray());
+                Assert.Equal(ModbusDataType.InputRegister, e.ModbusDataType);
             };
 
             dataStore.DataStoreWrittenTo += (obj, e) => writtenToEventFired = true;
 
             DataStore.ReadData<RegisterCollection, ushort>(dataStore, dataStore.InputRegisters, 4, 0, new object());
-            Assert.IsTrue(readFromEventFired);
-            Assert.IsFalse(writtenToEventFired);
+            Assert.True(readFromEventFired);
+            Assert.False(writtenToEventFired);
         }
 
-        [Test]
+        [Fact]
         public void DataStoreReadFromEvent_ReadInputs()
         {
             DataStore dataStore = DataStoreFactory.CreateTestDataStore();
@@ -159,19 +158,19 @@ namespace Modbus.UnitTests.Data
             dataStore.DataStoreReadFrom += (obj, e) =>
             {
                 readFromEventFired = true;
-                Assert.AreEqual(4, e.StartAddress);
-                Assert.AreEqual(new bool[] {false}, e.Data.A.ToArray());
-                Assert.AreEqual(ModbusDataType.Input, e.ModbusDataType);
+                Assert.Equal(4, e.StartAddress);
+                Assert.Equal(new bool[] {false}, e.Data.A.ToArray());
+                Assert.Equal(ModbusDataType.Input, e.ModbusDataType);
             };
 
             dataStore.DataStoreWrittenTo += (obj, e) => writtenToEventFired = true;
 
             DataStore.ReadData<DiscreteCollection, bool>(dataStore, dataStore.InputDiscretes, 4, 1, new object());
-            Assert.IsTrue(readFromEventFired);
-            Assert.IsFalse(writtenToEventFired);
+            Assert.True(readFromEventFired);
+            Assert.False(writtenToEventFired);
         }
 
-        [Test]
+        [Fact]
         public void DataStoreWrittenToEvent_WriteCoils()
         {
             DataStore dataStore = DataStoreFactory.CreateTestDataStore();
@@ -182,21 +181,21 @@ namespace Modbus.UnitTests.Data
             dataStore.DataStoreWrittenTo += (obj, e) =>
             {
                 writtenToEventFired = true;
-                Assert.AreEqual(3, e.Data.A.Count);
-                Assert.AreEqual(4, e.StartAddress);
-                Assert.AreEqual(new[] {true, false, true}, e.Data.A.ToArray());
-                Assert.AreEqual(ModbusDataType.Coil, e.ModbusDataType);
+                Assert.Equal(3, e.Data.A.Count);
+                Assert.Equal(4, e.StartAddress);
+                Assert.Equal(new[] {true, false, true}, e.Data.A.ToArray());
+                Assert.Equal(ModbusDataType.Coil, e.ModbusDataType);
             };
 
             dataStore.DataStoreReadFrom += (obj, e) => readFromEventFired = true;
 
             DataStore.WriteData(dataStore, new DiscreteCollection(true, false, true), dataStore.CoilDiscretes, 4,
                 new object());
-            Assert.IsFalse(readFromEventFired);
-            Assert.IsTrue(writtenToEventFired);
+            Assert.False(readFromEventFired);
+            Assert.True(writtenToEventFired);
         }
 
-        [Test]
+        [Fact]
         public void DataStoreWrittenToEvent_WriteHoldingRegisters()
         {
             DataStore dataStore = DataStoreFactory.CreateTestDataStore();
@@ -207,42 +206,42 @@ namespace Modbus.UnitTests.Data
             dataStore.DataStoreWrittenTo += (obj, e) =>
             {
                 writtenToEventFired = true;
-                Assert.AreEqual(3, e.Data.B.Count);
-                Assert.AreEqual(0, e.StartAddress);
-                Assert.AreEqual(new ushort[] {5, 6, 7}, e.Data.B.ToArray());
-                Assert.AreEqual(ModbusDataType.HoldingRegister, e.ModbusDataType);
+                Assert.Equal(3, e.Data.B.Count);
+                Assert.Equal(0, e.StartAddress);
+                Assert.Equal(new ushort[] {5, 6, 7}, e.Data.B.ToArray());
+                Assert.Equal(ModbusDataType.HoldingRegister, e.ModbusDataType);
             };
 
             dataStore.DataStoreReadFrom += (obj, e) => readFromEventFired = true;
 
             DataStore.WriteData(dataStore, new RegisterCollection(5, 6, 7), dataStore.HoldingRegisters, 0, new object());
-            Assert.IsFalse(readFromEventFired);
-            Assert.IsTrue(writtenToEventFired);
+            Assert.False(readFromEventFired);
+            Assert.True(writtenToEventFired);
         }
 
-        [Test]
+        [Fact]
         public void Update()
         {
             List<int> newItems = new List<int>(new int[] {4, 5, 6});
             List<int> destination = new List<int>(new int[] {1, 2, 3, 7, 8, 9});
             DataStore.Update<int>(newItems, destination, 3);
-            Assert.AreEqual(new int[] {1, 2, 3, 4, 5, 6}, destination.ToArray());
+            Assert.Equal(new int[] {1, 2, 3, 4, 5, 6}, destination.ToArray());
         }
 
-        [Test, ExpectedException(typeof(InvalidModbusRequestException))]
+        [Fact]
         public void UpdateItemsTooLarge()
         {
             List<int> newItems = new List<int>(new int[] {1, 2, 3, 7, 8, 9});
             List<int> destination = new List<int>(new int[] {4, 5, 6});
-            DataStore.Update<int>(newItems, destination, 3);
+            Assert.Throws<InvalidModbusRequestException>(() => DataStore.Update<int>(newItems, destination, 3));
         }
 
-        [Test, ExpectedException(typeof(InvalidModbusRequestException))]
+        [Fact]
         public void UpdateNegativeIndex()
         {
             List<int> newItems = new List<int>(new int[] {1, 2, 3, 7, 8, 9});
             List<int> destination = new List<int>(new int[] {4, 5, 6});
-            DataStore.Update<int>(newItems, destination, -1);
+            Assert.Throws<InvalidModbusRequestException>(() => DataStore.Update<int>(newItems, destination, -1));
         }
     }
 }

--- a/NModbus4.UnitTests/Data/DiscreteCollectionFixture.cs
+++ b/NModbus4.UnitTests/Data/DiscreteCollectionFixture.cs
@@ -1,100 +1,98 @@
 using System.Linq;
 using Modbus.Data;
+using Xunit;
 
 namespace Modbus.UnitTests.Data
 {
-    using NUnit.Framework;
-
-    [TestFixture]
     public class DiscreteCollectionFixture
     {
-        [Test]
+        [Fact]
         public void ByteCount()
         {
             DiscreteCollection col = new DiscreteCollection(true, true, false, false, false, false, false, false, false);
-            Assert.AreEqual(2, col.ByteCount);
+            Assert.Equal(2, col.ByteCount);
         }
 
-        [Test]
+        [Fact]
         public void ByteCountEven()
         {
             DiscreteCollection col = new DiscreteCollection(true, true, false, false, false, false, false, false);
-            Assert.AreEqual(1, col.ByteCount);
+            Assert.Equal(1, col.ByteCount);
         }
 
-        [Test]
+        [Fact]
         public void NetworkBytes()
         {
             DiscreteCollection col = new DiscreteCollection(true, true);
-            Assert.AreEqual(new byte[] {3}, col.NetworkBytes);
+            Assert.Equal(new byte[] {3}, col.NetworkBytes);
         }
 
-        [Test]
+        [Fact]
         public void CreateNewDiscreteCollectionInitialize()
         {
             DiscreteCollection col = new DiscreteCollection(true, true, true);
-            Assert.AreEqual(3, col.Count);
-            Assert.IsFalse(col.Contains(false));
+            Assert.Equal(3, col.Count);
+            Assert.False(col.Contains(false));
         }
 
-        [Test]
+        [Fact]
         public void CreateNewDiscreteCollectionFromBoolParams()
         {
             DiscreteCollection col = new DiscreteCollection(true, false, true);
-            Assert.AreEqual(3, col.Count);
+            Assert.Equal(3, col.Count);
         }
 
-        [Test]
+        [Fact]
         public void CreateNewDiscreteCollectionFromBytesParams()
         {
             DiscreteCollection col = new DiscreteCollection(1, 2, 3);
-            Assert.AreEqual(24, col.Count);
+            Assert.Equal(24, col.Count);
         }
 
-        [Test]
+        [Fact]
         public void CreateNewDiscreteCollectionFromBytesParamsOrder()
         {
             DiscreteCollection col = new DiscreteCollection(194);
-            Assert.AreEqual(new bool[] {false, true, false, false, false, false, true, true}, col.ToArray());
+            Assert.Equal(new bool[] {false, true, false, false, false, false, true, true}, col.ToArray());
         }
 
-        [Test]
+        [Fact]
         public void CreateNewDiscreteCollectionFromBytesParamsOrder2()
         {
             DiscreteCollection col = new DiscreteCollection(157, 7);
-            Assert.AreEqual(
+            Assert.Equal(
                 new bool[]
                 {true, false, true, true, true, false, false, true, true, true, true, false, false, false, false, false},
                 col.ToArray());
         }
 
-        [Test]
+        [Fact]
         public void Resize()
         {
             DiscreteCollection col = new DiscreteCollection(byte.MaxValue, byte.MaxValue);
-            Assert.AreEqual(16, col.Count);
+            Assert.Equal(16, col.Count);
             col.RemoveAt(3);
-            Assert.AreEqual(15, col.Count);
+            Assert.Equal(15, col.Count);
         }
 
-        [Test]
+        [Fact]
         public void BytesPersistence()
         {
             DiscreteCollection col = new DiscreteCollection(byte.MaxValue, byte.MaxValue);
-            Assert.AreEqual(16, col.Count);
+            Assert.Equal(16, col.Count);
             byte[] originalBytes = col.NetworkBytes;
             col.RemoveAt(3);
-            Assert.AreEqual(15, col.Count);
-            Assert.AreNotEqual(originalBytes, col.NetworkBytes);
+            Assert.Equal(15, col.Count);
+            Assert.NotEqual(originalBytes, col.NetworkBytes);
         }
 
-        [Test]
+        [Fact]
         public void AddCoil()
         {
             DiscreteCollection col = new DiscreteCollection();
-            Assert.AreEqual(0, col.Count);
+            Assert.Equal(0, col.Count);
             col.Add(true);
-            Assert.AreEqual(1, col.Count);
+            Assert.Equal(1, col.Count);
         }
     }
 }

--- a/NModbus4.UnitTests/Data/ModbusDataCollectionFixture.cs
+++ b/NModbus4.UnitTests/Data/ModbusDataCollectionFixture.cs
@@ -1,85 +1,83 @@
 using System;
 using System.Linq;
 using Modbus.Data;
+using Xunit;
 
 namespace Modbus.UnitTests.Data
 {
-    using NUnit.Framework;
-
-    [TestFixture]
     public class ModbusDataCollectionFixture
     {
-        [Test]
+        [Fact]
         public void FromReadOnlyList()
         {
             ModbusDataCollection<bool> col = new ModbusDataCollection<bool>(new bool[] {true, false});
-            Assert.AreEqual(3, col.Count);
+            Assert.Equal(3, col.Count);
         }
 
-        [Test]
+        [Fact]
         public void ModbusDataCollection_FromParams()
         {
             ModbusDataCollection<bool> col = new ModbusDataCollection<bool>(true, false);
-            Assert.AreEqual(3, col.Count);
+            Assert.Equal(3, col.Count);
         }
 
-        [Test]
+        [Fact]
         public void Empty()
         {
             ModbusDataCollection<bool> col = new ModbusDataCollection<bool>();
-            Assert.AreEqual(1, col.Count);
+            Assert.Equal(1, col.Count);
         }
 
-        [Test]
+        [Fact]
         public void AddDefaultBool()
         {
             ModbusDataCollection<bool> col = new ModbusDataCollection<bool>(true, true);
-            Assert.AreEqual(3, col.Count);
-            Assert.AreEqual(new bool[] {false, true, true}, col.ToArray());
+            Assert.Equal(3, col.Count);
+            Assert.Equal(new bool[] {false, true, true}, col.ToArray());
         }
 
-        [Test]
+        [Fact]
         public void AddDefaultUshort()
         {
             ModbusDataCollection<ushort> col = new ModbusDataCollection<ushort>(1, 1);
-            Assert.AreEqual(3, col.Count);
-            Assert.AreEqual(new ushort[] {0, 1, 1}, col.ToArray());
+            Assert.Equal(3, col.Count);
+            Assert.Equal(new ushort[] {0, 1, 1}, col.ToArray());
         }
 
-        [Test, ExpectedException(typeof (ArgumentOutOfRangeException))]
+        [Fact]
         public void SetZeroElementUsingItem()
         {
             ModbusDataCollection<bool> col = new ModbusDataCollection<bool>(true, false);
-            col[0] = true;
+            Assert.Throws<ArgumentOutOfRangeException>(() => col[0] = true);
         }
 
-        [Test, ExpectedException(typeof (ArgumentOutOfRangeException))]
+        [Fact]
         public void InsertZeroElement()
         {
             ModbusDataCollection<bool> col = new ModbusDataCollection<bool>(true, false);
-            col.Insert(0, true);
+            Assert.Throws<ArgumentOutOfRangeException>(() => col.Insert(0, true));
         }
 
-        [Test]
+        [Fact]
         public void Clear()
         {
             ModbusDataCollection<bool> col = new ModbusDataCollection<bool>(true, false);
             col.Clear();
-            Assert.AreEqual(1, col.Count);
+            Assert.Equal(1, col.Count);
         }
 
-        [Test, ExpectedException(typeof (ArgumentOutOfRangeException))]
+        [Fact]
         public void RemoveAtZeroElement()
         {
             ModbusDataCollection<bool> col = new ModbusDataCollection<bool>(true, false);
-            col.RemoveAt(0);
+            Assert.Throws<ArgumentOutOfRangeException>(() => col.RemoveAt(0));
         }
 
-        [Test, ExpectedException(typeof (ArgumentOutOfRangeException))]
+        [Fact]
         public void RemoveZeroElement()
         {
             ModbusDataCollection<bool> col = new ModbusDataCollection<bool>();
-            col.Remove(default(bool));
+            Assert.Throws<ArgumentOutOfRangeException>(() => col.Remove(default(bool)));
         }
     }
 }

--- a/NModbus4.UnitTests/Data/RegisterCollectionFixture.cs
+++ b/NModbus4.UnitTests/Data/RegisterCollectionFixture.cs
@@ -1,80 +1,78 @@
 using Modbus.Data;
+using Xunit;
 
 namespace Modbus.UnitTests.Data
 {
-    using NUnit.Framework;
-
-    [TestFixture]
     public class RegisterCollectionFixture
     {
-        [Test]
+        [Fact]
         public void ByteCount()
         {
             RegisterCollection col = new RegisterCollection(1, 2, 3);
-            Assert.AreEqual(6, col.ByteCount);
+            Assert.Equal(6, col.ByteCount);
         }
 
-        [Test]
+        [Fact]
         public void NewRegisterCollection()
         {
             RegisterCollection col = new RegisterCollection(5, 3, 4, 6);
-            Assert.IsNotNull(col);
-            Assert.AreEqual(4, col.Count);
-            Assert.AreEqual(5, col[0]);
+            Assert.NotNull(col);
+            Assert.Equal(4, col.Count);
+            Assert.Equal(5, col[0]);
         }
 
-        [Test]
+        [Fact]
         public void NewRegisterCollectionFromBytes()
         {
             RegisterCollection col = new RegisterCollection(new byte[] {0, 1, 0, 2, 0, 3});
-            Assert.IsNotNull(col);
-            Assert.AreEqual(3, col.Count);
-            Assert.AreEqual(1, col[0]);
-            Assert.AreEqual(2, col[1]);
-            Assert.AreEqual(3, col[2]);
+            Assert.NotNull(col);
+            Assert.Equal(3, col.Count);
+            Assert.Equal(1, col[0]);
+            Assert.Equal(2, col[1]);
+            Assert.Equal(3, col[2]);
         }
 
-        [Test]
+        [Fact]
         public void RegisterCollectionNetworkBytes()
         {
             RegisterCollection col = new RegisterCollection(5, 3, 4, 6);
             byte[] bytes = col.NetworkBytes;
-            Assert.IsNotNull(bytes);
-            Assert.AreEqual(8, bytes.Length);
-            Assert.AreEqual(new byte[] {0, 5, 0, 3, 0, 4, 0, 6}, bytes);
+            Assert.NotNull(bytes);
+            Assert.Equal(8, bytes.Length);
+            Assert.Equal(new byte[] {0, 5, 0, 3, 0, 4, 0, 6}, bytes);
         }
 
-        [Test]
+        [Fact]
         public void RegisterCollectionEmpty()
         {
             RegisterCollection col = new RegisterCollection();
-            Assert.IsNotNull(col);
-            Assert.AreEqual(0, col.NetworkBytes.Length);
+            Assert.NotNull(col);
+            Assert.Equal(0, col.NetworkBytes.Length);
         }
 
-        [Test]
+        [Fact]
         public void ModifyRegister()
         {
             RegisterCollection col = new RegisterCollection(1, 2, 3, 4);
             col[0] = 5;
         }
 
-        [Test]
+        [Fact]
         public void AddRegister()
         {
             RegisterCollection col = new RegisterCollection();
-            Assert.AreEqual(0, col.Count);
+            Assert.Equal(0, col.Count);
             col.Add(45);
-            Assert.AreEqual(1, col.Count);
+            Assert.Equal(1, col.Count);
         }
 
-        [Test]
+        [Fact]
         public void RemoveRegister()
         {
             RegisterCollection col = new RegisterCollection(3, 4, 5);
-            Assert.AreEqual(3, col.Count);
+            Assert.Equal(3, col.Count);
             col.RemoveAt(2);
-            Assert.AreEqual(2, col.Count);
+            Assert.Equal(2, col.Count);
         }
     }
 }

--- a/NModbus4.UnitTests/Device/ModbusMasterFixture.cs
+++ b/NModbus4.UnitTests/Device/ModbusMasterFixture.cs
@@ -3,15 +3,13 @@ using System.Linq;
 using Modbus.Device;
 using Modbus.IO;
 using Rhino.Mocks;
+using Xunit;
 
 namespace Modbus.UnitTests.Device
 {
-    using NUnit.Framework;
-
-    [TestFixture]
     public class ModbusMasterFixture
     {
-        [Test]
+        [Fact]
         public void ReadCoils()
         {
             var mockSerialResource = MockRepository.GenerateStub<IStreamResource>();
@@ -21,7 +19,7 @@ namespace Modbus.UnitTests.Device
             Assert.Throws<ArgumentException>(() => master.ReadCoils(1, 1, 2001));
         }
 
-        [Test]
+        [Fact]
         public void ReadInputs()
         {
             var mockSerialResource = MockRepository.GenerateStub<IStreamResource>();
@@ -31,7 +29,7 @@ namespace Modbus.UnitTests.Device
             Assert.Throws<ArgumentException>(() => master.ReadInputs(1, 1, 2001));
         }
 
-        [Test]
+        [Fact]
         public void ReadHoldingRegisters()
         {
             var mockSerialResource = MockRepository.GenerateStub<IStreamResource>();
@@ -41,7 +39,7 @@ namespace Modbus.UnitTests.Device
             Assert.Throws<ArgumentException>(() => master.ReadHoldingRegisters(1, 1, 126));
         }
 
-        [Test]
+        [Fact]
         public void ReadInputRegisters()
         {
             var mockSerialResource = MockRepository.GenerateStub<IStreamResource>();
@@ -51,7 +49,7 @@ namespace Modbus.UnitTests.Device
             Assert.Throws<ArgumentException>(() => master.ReadInputRegisters(1, 1, 126));
         }
 
-        [Test]
+        [Fact]
         public void WriteMultipleRegisters()
         {
             var mockSerialResource = MockRepository.GenerateStub<IStreamResource>();
@@ -63,7 +61,7 @@ namespace Modbus.UnitTests.Device
                 () => master.WriteMultipleRegisters(1, 1, Enumerable.Repeat<ushort>(1, 124).ToArray()));
         }
 
-        [Test]
+        [Fact]
         public void WriteMultipleCoils()
         {
             var mockSerialResource = MockRepository.GenerateStub<IStreamResource>();
@@ -75,7 +73,7 @@ namespace Modbus.UnitTests.Device
                 () => master.WriteMultipleCoils(1, 1, Enumerable.Repeat<bool>(false, 1969).ToArray()));
         }
 
-        [Test]
+        [Fact]
         public void ReadWriteMultipleRegisters()
         {
             var mockSerialResource = MockRepository.GenerateStub<IStreamResource>();

--- a/NModbus4.UnitTests/Device/ModbusSlaveFixture.cs
+++ b/NModbus4.UnitTests/Device/ModbusSlaveFixture.cs
@@ -4,24 +4,21 @@ using Modbus.Data;
 using Modbus.Device;
 using Modbus.Message;
 using Modbus.UnitTests.Message;
+using Modbus.Unme.Common;
+using Xunit;
 
 namespace Modbus.UnitTests.Device
 {
-    using Unme.Common;
-    using NUnit.Framework;
-
-    [TestFixture]
     public class ModbusSlaveFixture : ModbusMessageFixture
     {
         private DataStore _testDataStore;
 
-        [SetUp]
-        public void SetUp()
+        public ModbusSlaveFixture()
         {
             _testDataStore = DataStoreFactory.CreateTestDataStore();
         }
-
-        [Test]
+        
+        [Fact]
         public void ReadDiscretesCoils()
         {
             ReadCoilsInputsResponse expectedResponse = new ReadCoilsInputsResponse(Modbus.ReadCoils, 1, 2,
@@ -30,10 +27,10 @@ namespace Modbus.UnitTests.Device
                 ModbusSlave.ReadDiscretes(new ReadCoilsInputsRequest(Modbus.ReadCoils, 1, 1, 9), _testDataStore,
                     _testDataStore.CoilDiscretes);
             AssertModbusMessagePropertiesAreEqual(expectedResponse, response);
-            Assert.AreEqual(expectedResponse.ByteCount, response.ByteCount);
+            Assert.Equal(expectedResponse.ByteCount, response.ByteCount);
         }
 
-        [Test]
+        [Fact]
         public void ReadDiscretesInputs()
         {
             ReadCoilsInputsResponse expectedResponse = new ReadCoilsInputsResponse(Modbus.ReadInputs, 1, 2,
@@ -42,10 +39,10 @@ namespace Modbus.UnitTests.Device
                 ModbusSlave.ReadDiscretes(new ReadCoilsInputsRequest(Modbus.ReadInputs, 1, 1, 9), _testDataStore,
                     _testDataStore.InputDiscretes);
             AssertModbusMessagePropertiesAreEqual(expectedResponse, response);
-            Assert.AreEqual(expectedResponse.ByteCount, response.ByteCount);
+            Assert.Equal(expectedResponse.ByteCount, response.ByteCount);
         }
 
-        [Test]
+        [Fact]
         public void ReadRegistersHoldingRegisters()
         {
             ReadHoldingInputRegistersResponse expectedResponse =
@@ -55,10 +52,10 @@ namespace Modbus.UnitTests.Device
                 ModbusSlave.ReadRegisters(new ReadHoldingInputRegistersRequest(Modbus.ReadHoldingRegisters, 1, 0, 6),
                     _testDataStore, _testDataStore.HoldingRegisters);
             AssertModbusMessagePropertiesAreEqual(expectedResponse, response);
-            Assert.AreEqual(expectedResponse.ByteCount, response.ByteCount);
+            Assert.Equal(expectedResponse.ByteCount, response.ByteCount);
         }
 
-        [Test]
+        [Fact]
         public void ReadRegistersInputRegisters()
         {
             ReadHoldingInputRegistersResponse expectedResponse =
@@ -68,10 +65,10 @@ namespace Modbus.UnitTests.Device
                 ModbusSlave.ReadRegisters(new ReadHoldingInputRegistersRequest(Modbus.ReadInputRegisters, 1, 0, 6),
                     _testDataStore, _testDataStore.InputRegisters);
             AssertModbusMessagePropertiesAreEqual(expectedResponse, response);
-            Assert.AreEqual(expectedResponse.ByteCount, response.ByteCount);
+            Assert.Equal(expectedResponse.ByteCount, response.ByteCount);
         }
 
-        [Test]
+        [Fact]
         public void WriteSingleCoil()
         {
             ushort addressToWrite = 35;
@@ -82,10 +79,10 @@ namespace Modbus.UnitTests.Device
                 ModbusSlave.WriteSingleCoil(new WriteSingleCoilRequestResponse(1, addressToWrite, valueToWrite),
                     _testDataStore, _testDataStore.CoilDiscretes);
             AssertModbusMessagePropertiesAreEqual(expectedResponse, response);
-            Assert.AreEqual(valueToWrite, _testDataStore.CoilDiscretes[addressToWrite + 1]);
+            Assert.Equal(valueToWrite, _testDataStore.CoilDiscretes[addressToWrite + 1]);
         }
 
-        [Test]
+        [Fact]
         public void WriteMultipleCoils()
         {
             ushort startAddress = 35;
@@ -98,16 +95,16 @@ namespace Modbus.UnitTests.Device
                         new DiscreteCollection(val, val, val, val, val, val, val, val, val, val)), _testDataStore,
                     _testDataStore.CoilDiscretes);
             AssertModbusMessagePropertiesAreEqual(expectedResponse, response);
-            Assert.AreEqual(new bool[] {val, val, val, val, val, val, val, val, val, val},
+            Assert.Equal(new bool[] {val, val, val, val, val, val, val, val, val, val},
                 _testDataStore.CoilDiscretes.Slice(startAddress + 1, numberOfPoints).ToArray());
         }
 
-        [Test]
+        [Fact]
         public void WriteSingleRegister()
         {
             ushort startAddress = 35;
             ushort value = 45;
-            Assert.AreNotEqual(value, _testDataStore.HoldingRegisters[startAddress - 1]);
+            Assert.NotEqual(value, _testDataStore.HoldingRegisters[startAddress - 1]);
             WriteSingleRegisterRequestResponse expectedResponse = new WriteSingleRegisterRequestResponse(1, startAddress,
                 value);
             WriteSingleRegisterRequestResponse response =
@@ -116,12 +113,12 @@ namespace Modbus.UnitTests.Device
             AssertModbusMessagePropertiesAreEqual(expectedResponse, response);
         }
 
-        [Test]
+        [Fact]
         public void WriteMultipleRegisters()
         {
             ushort startAddress = 35;
             ushort[] valuesToWrite = new ushort[] {1, 2, 3, 4, 5};
-            Assert.AreNotEqual(valuesToWrite,
+            Assert.NotEqual(valuesToWrite,
                 _testDataStore.HoldingRegisters.Slice(startAddress - 1, valuesToWrite.Length).ToArray());
             WriteMultipleRegistersResponse expectedResponse = new WriteMultipleRegistersResponse(1, startAddress,
                 (ushort) valuesToWrite.Length);
@@ -132,7 +129,7 @@ namespace Modbus.UnitTests.Device
             AssertModbusMessagePropertiesAreEqual(expectedResponse, response);
         }
 
-        [Test]
+        [Fact]
         public void ApplyRequest_VerifyModbusRequestReceivedEventIsFired()
         {
             bool eventFired = false;
@@ -141,14 +138,14 @@ namespace Modbus.UnitTests.Device
             slave.ModbusSlaveRequestReceived += (obj, args) =>
             {
                 eventFired = true;
-                Assert.AreEqual(request, args.Message);
+                Assert.Equal(request, args.Message);
             };
 
             slave.ApplyRequest(request);
-            Assert.IsTrue(eventFired);
+            Assert.True(eventFired);
         }
 
-        [Test]
+        [Fact]
         public void WriteMultipCoils_MakeSureWeDoNotWriteRemainder()
         {
             // 0, false initialized data store
@@ -158,7 +155,7 @@ namespace Modbus.UnitTests.Device
                 new DiscreteCollection(Enumerable.Repeat(true, 8).ToArray())) {NumberOfPoints = 2};
             ModbusSlave.WriteMultipleCoils(request, dataStore, dataStore.CoilDiscretes);
 
-            Assert.AreEqual(dataStore.CoilDiscretes.Slice(1, 8).ToArray(),
+            Assert.Equal(dataStore.CoilDiscretes.Slice(1, 8).ToArray(),
                 new[] {true, true, false, false, false, false, false, false});
         }
     }

--- a/NModbus4.UnitTests/Device/TcpConnectionEventArgsFixture.cs
+++ b/NModbus4.UnitTests/Device/TcpConnectionEventArgsFixture.cs
@@ -1,31 +1,29 @@
 ﻿using System;
 using Modbus.Device;
+using Xunit;
 
 namespace Modbus.UnitTests.Device
 {
-    using NUnit.Framework;
-
-    [TestFixture]
     public class TcpConnectionEventArgsFixture
     {
-        [Test, ExpectedException(typeof (ArgumentNullException))]
+        [Fact]
         public void TcpConnectionEventArgs_NullEndPoint()
         {
-            new TcpConnectionEventArgs(null);
+            Assert.Throws<ArgumentNullException>(() => new TcpConnectionEventArgs(null));
         }
 
-        [Test, ExpectedException(typeof (ArgumentException))]
+        [Fact]
         public void TcpConnectionEventArgs_EmptyEndPoint()
         {
-            new TcpConnectionEventArgs(String.Empty);
+            Assert.Throws<ArgumentException>(() => new TcpConnectionEventArgs(String.Empty));
         }
 
-        [Test]
+        [Fact]
         public void TcpConnectionEventArgs()
         {
             var args = new TcpConnectionEventArgs("foo");
 
-            Assert.AreEqual("foo", args.EndPoint);
+            Assert.Equal("foo", args.EndPoint);
         }
     }
 }

--- a/NModbus4.UnitTests/IO/ModbusAsciiTransportFixture.cs
+++ b/NModbus4.UnitTests/IO/ModbusAsciiTransportFixture.cs
@@ -1,30 +1,28 @@
 using System;
 using System.IO;
-using System.IO.Ports;
 using System.Text;
 using Modbus.IO;
 using Modbus.Message;
 using Modbus.UnitTests.Message;
 using Rhino.Mocks;
+using Xunit;
 
 namespace Modbus.UnitTests.IO
 {
-    using NUnit.Framework;
 
-    [TestFixture]
     public class ModbusAsciiTransportFixture : ModbusMessageFixture
     {
-        [Test]
+        [Fact]
         public void BuildMessageFrame()
         {
             byte[] expected = {58, 48, 50, 48, 49, 48, 48, 48, 48, 48, 48, 48, 49, 70, 67, 13, 10};
             ReadCoilsInputsRequest request = new ReadCoilsInputsRequest(Modbus.ReadCoils, 2, 0, 1);
             var actual =
                 new ModbusAsciiTransport(MockRepository.GenerateStub<IStreamResource>()).BuildMessageFrame(request);
-            Assert.AreEqual(expected, actual);
+            Assert.Equal(expected, actual);
         }
 
-        [Test]
+        [Fact]
         public void ReadRequestResponse()
         {
             var mocks = new MockRepository();
@@ -35,48 +33,42 @@ namespace Modbus.UnitTests.IO
 
             mocks.ReplayAll();
 
-            Assert.AreEqual(new byte[] {17, 1, 0, 19, 0, 37, 182}, transport.ReadRequestResponse());
+            Assert.Equal(new byte[] {17, 1, 0, 19, 0, 37, 182}, transport.ReadRequestResponse());
 
             mocks.VerifyAll();
         }
 
-        [Test, ExpectedException(typeof (IOException))]
+        [Fact]
         public void ReadRequestResponseNotEnoughBytes()
         {
             MockRepository mocks = new MockRepository();
             IStreamResource mockSerialResource = mocks.StrictMock<IStreamResource>();
-            Expect.Call(mockSerialResource.ReadTimeout).Return(SerialPort.InfiniteTimeout);
-            mockSerialResource.WriteTimeout = 0;
-            LastCall.IgnoreArguments();
-            Expect.Call(mockSerialResource.WriteTimeout).Return(SerialPort.InfiniteTimeout);
-            mockSerialResource.ReadTimeout = 0;
-            LastCall.IgnoreArguments();
 
             var mockTransport = mocks.PartialMock<ModbusAsciiTransport>(mockSerialResource);
             ExpectReadLine(mockSerialResource, Encoding.ASCII.GetBytes(":10\r\n"));
             mocks.ReplayAll();
 
-            mockTransport.ReadRequestResponse();
+            Assert.Throws<IOException>(() => mockTransport.ReadRequestResponse());
 
             mocks.VerifyAll();
         }
 
-        [Test]
+        [Fact]
         public void ChecksumsMatchSucceed()
         {
             ModbusAsciiTransport transport = new ModbusAsciiTransport(MockRepository.GenerateStub<IStreamResource>());
             ReadCoilsInputsRequest message = new ReadCoilsInputsRequest(Modbus.ReadCoils, 17, 19, 37);
             byte[] frame = {17, Modbus.ReadCoils, 0, 19, 0, 37, 182};
-            Assert.IsTrue(transport.ChecksumsMatch(message, frame));
+            Assert.True(transport.ChecksumsMatch(message, frame));
         }
 
-        [Test]
+        [Fact]
         public void ChecksumsMatchFail()
         {
             ModbusAsciiTransport transport = new ModbusAsciiTransport(MockRepository.GenerateStub<IStreamResource>());
             ReadCoilsInputsRequest message = new ReadCoilsInputsRequest(Modbus.ReadCoils, 17, 19, 37);
             byte[] frame = {17, Modbus.ReadCoils, 0, 19, 0, 37, 181};
-            Assert.IsFalse(transport.ChecksumsMatch(message, frame));
+            Assert.False(transport.ChecksumsMatch(message, frame));
         }
 
         private static void ExpectReadLine(IStreamResource stream, byte[] frame)
@@ -88,10 +80,10 @@ namespace Modbus.UnitTests.IO
                 byte tempByte = b;
                 Expect.Call(stream.Read(new byte[] {lastByte}, 0, 1))
                     .Do(((Func<byte[], int, int, int>) delegate(byte[] buf, int offset, int count)
-                    {
-                        Array.Copy(new byte[] {tempByte}, buf, 1);
-                        return 1;
-                    }));
+                   {
+                       Array.Copy(new byte[] {tempByte}, buf, 1);
+                       return 1;
+                   }));
 
                 lastByte = tempByte;
             }

--- a/NModbus4.UnitTests/IO/ModbusRtuTransportFixture.cs
+++ b/NModbus4.UnitTests/IO/ModbusRtuTransportFixture.cs
@@ -6,122 +6,118 @@ using Modbus.IO;
 using Modbus.Message;
 using Modbus.Utility;
 using Rhino.Mocks;
+using Xunit;
 
 namespace Modbus.UnitTests.IO
 {
-    using Unme.Common;
-    using NUnit.Framework;
 
-    [TestFixture]
     public class ModbusRtuTransportFixture
     {
-        [Test]
+        [Fact]
         public void BuildMessageFrame()
         {
             byte[] message = {17, Modbus.ReadCoils, 0, 19, 0, 37, 14, 132};
             ReadCoilsInputsRequest request = new ReadCoilsInputsRequest(Modbus.ReadCoils, 17, 19, 37);
-            Assert.AreEqual(message,
+            Assert.Equal(message,
                 new ModbusRtuTransport(MockRepository.GenerateStub<IStreamResource>()).BuildMessageFrame(request));
         }
 
-        [Test]
+        [Fact]
         public void ResponseBytesToReadCoils()
         {
             byte[] frameStart = {0x11, 0x01, 0x05, 0xCD, 0x6B, 0xB2, 0x0E, 0x1B};
-            Assert.AreEqual(6, ModbusRtuTransport.ResponseBytesToRead(frameStart));
+            Assert.Equal(6, ModbusRtuTransport.ResponseBytesToRead(frameStart));
         }
 
-        [Test]
+        [Fact]
         public void ResponseBytesToReadCoilsNoData()
         {
             byte[] frameStart = {0x11, 0x01, 0x00, 0x00, 0x00};
-            Assert.AreEqual(1, ModbusRtuTransport.ResponseBytesToRead(frameStart));
+            Assert.Equal(1, ModbusRtuTransport.ResponseBytesToRead(frameStart));
         }
 
-        [Test]
+        [Fact]
         public void ResponseBytesToReadWriteCoilsResponse()
         {
             byte[] frameStart = {0x11, 0x0F, 0x00, 0x13, 0x00, 0x0A, 0, 0};
-            Assert.AreEqual(4, ModbusRtuTransport.ResponseBytesToRead(frameStart));
+            Assert.Equal(4, ModbusRtuTransport.ResponseBytesToRead(frameStart));
         }
 
-        [Test]
+        [Fact]
         public void ResponseBytesToReadDiagnostics()
         {
             byte[] frameStart = {0x01, 0x08, 0x00, 0x00};
-            Assert.AreEqual(4, ModbusRtuTransport.ResponseBytesToRead(frameStart));
+            Assert.Equal(4, ModbusRtuTransport.ResponseBytesToRead(frameStart));
         }
 
-        [Test]
+        [Fact]
         public void ResponseBytesToReadSlaveException()
         {
             byte[] frameStart = {0x01, Modbus.ExceptionOffset + 1, 0x01};
-            Assert.AreEqual(1, ModbusRtuTransport.ResponseBytesToRead(frameStart));
+            Assert.Equal(1, ModbusRtuTransport.ResponseBytesToRead(frameStart));
         }
 
-        [Test, ExpectedException(typeof (NotImplementedException))]
+        [Fact]
         public void ResponseBytesToReadInvalidFunctionCode()
         {
             byte[] frame = {0x11, 0x16, 0x00, 0x01, 0x00, 0x02, 0x04};
-            ModbusRtuTransport.ResponseBytesToRead(frame);
-            Assert.Fail();
+            Assert.Throws<NotImplementedException>(() => ModbusRtuTransport.ResponseBytesToRead(frame));
         }
 
-        [Test]
+        [Fact]
         public void RequestBytesToReadDiagnostics()
         {
             byte[] frame = {0x01, 0x08, 0x00, 0x00, 0xA5, 0x37, 0, 0};
-            Assert.AreEqual(1, ModbusRtuTransport.RequestBytesToRead(frame));
+            Assert.Equal(1, ModbusRtuTransport.RequestBytesToRead(frame));
         }
 
-        [Test]
+        [Fact]
         public void RequestBytesToReadCoils()
         {
             byte[] frameStart = {0x11, 0x01, 0x00, 0x13, 0x00, 0x25};
-            Assert.AreEqual(1, ModbusRtuTransport.RequestBytesToRead(frameStart));
+            Assert.Equal(1, ModbusRtuTransport.RequestBytesToRead(frameStart));
         }
 
-        [Test]
+        [Fact]
         public void RequestBytesToReadWriteCoilsRequest()
         {
             byte[] frameStart = {0x11, 0x0F, 0x00, 0x13, 0x00, 0x0A, 0x02, 0xCD, 0x01};
-            Assert.AreEqual(4, ModbusRtuTransport.RequestBytesToRead(frameStart));
+            Assert.Equal(4, ModbusRtuTransport.RequestBytesToRead(frameStart));
         }
 
-        [Test]
+        [Fact]
         public void RequestBytesToReadWriteMultipleHoldingRegisters()
         {
             byte[] frameStart = {0x11, 0x10, 0x00, 0x01, 0x00, 0x02, 0x04};
-            Assert.AreEqual(6, ModbusRtuTransport.RequestBytesToRead(frameStart));
+            Assert.Equal(6, ModbusRtuTransport.RequestBytesToRead(frameStart));
         }
 
-        [Test, ExpectedException(typeof (NotImplementedException))]
+        [Fact]
         public void RequestBytesToReadInvalidFunctionCode()
         {
             byte[] frame = {0x11, 0xFF, 0x00, 0x01, 0x00, 0x02, 0x04};
-            ModbusRtuTransport.RequestBytesToRead(frame);
-            Assert.Fail();
+            Assert.Throws<NotImplementedException>(() => ModbusRtuTransport.RequestBytesToRead(frame));
         }
 
-        [Test]
+        [Fact]
         public void ChecksumsMatchSucceed()
         {
             ModbusRtuTransport transport = new ModbusRtuTransport(MockRepository.GenerateStub<IStreamResource>());
             ReadCoilsInputsRequest message = new ReadCoilsInputsRequest(Modbus.ReadCoils, 17, 19, 37);
             byte[] frame = {17, Modbus.ReadCoils, 0, 19, 0, 37, 14, 132};
-            Assert.IsTrue(transport.ChecksumsMatch(message, frame));
+            Assert.True(transport.ChecksumsMatch(message, frame));
         }
 
-        [Test]
+        [Fact]
         public void ChecksumsMatchFail()
         {
             ModbusRtuTransport transport = new ModbusRtuTransport(MockRepository.GenerateStub<IStreamResource>());
             ReadCoilsInputsRequest message = new ReadCoilsInputsRequest(Modbus.ReadCoils, 17, 19, 38);
             byte[] frame = {17, Modbus.ReadCoils, 0, 19, 0, 37, 14, 132};
-            Assert.IsFalse(transport.ChecksumsMatch(message, frame));
+            Assert.False(transport.ChecksumsMatch(message, frame));
         }
 
-        [Test]
+        [Fact]
         public void ReadResponse()
         {
             MockRepository mocks = new MockRepository();
@@ -138,15 +134,15 @@ namespace Modbus.UnitTests.IO
 
             ReadCoilsInputsResponse response =
                 transport.ReadResponse<ReadCoilsInputsResponse>() as ReadCoilsInputsResponse;
-            Assert.IsNotNull(response);
+            Assert.NotNull(response);
             ReadCoilsInputsResponse expectedResponse = new ReadCoilsInputsResponse(Modbus.ReadCoils, 1, 1,
                 new DiscreteCollection(false));
-            Assert.AreEqual(response.MessageFrame, expectedResponse.MessageFrame);
+            Assert.Equal(response.MessageFrame, expectedResponse.MessageFrame);
 
             mocks.VerifyAll();
         }
 
-        [Test]
+        [Fact]
         public void ReadResponseSlaveException()
         {
             MockRepository mocks = new MockRepository();
@@ -164,7 +160,7 @@ namespace Modbus.UnitTests.IO
 
             mocks.ReplayAll();
 
-            Assert.IsTrue(transport.ReadResponse<ReadCoilsInputsResponse>() is SlaveExceptionResponse);
+            Assert.True(transport.ReadResponse<ReadCoilsInputsResponse>() is SlaveExceptionResponse);
 
             mocks.VerifyAll();
         }
@@ -173,7 +169,7 @@ namespace Modbus.UnitTests.IO
         ///     We want to throw an IOException for any message w/ an invalid checksum,
         ///     this must preceed throwing a SlaveException based on function code > 127
         /// </summary>
-        [Test, ExpectedException(typeof (IOException))]
+        [Fact]
         public void ReadResponseSlaveExceptionWithErroneousLrc()
         {
             MockRepository mocks = new MockRepository();
@@ -185,19 +181,19 @@ namespace Modbus.UnitTests.IO
             byte[] crc = {0x9, 0x9};
 
             Expect.Call(transport.Read(ModbusRtuTransport.ResponseFrameStartLength))
-                .Return(Enumerable.Concat(messageFrame, new byte [] { crc[0] }).ToArray());
+                .Return(Enumerable.Concat(messageFrame, new byte[] { crc[0] }).ToArray());
 
             Expect.Call(transport.Read(1))
                 .Return(new byte[] {crc[1]});
 
             mocks.ReplayAll();
 
-            transport.ReadResponse<ReadCoilsInputsResponse>();
+            Assert.Throws<IOException>(() => transport.ReadResponse<ReadCoilsInputsResponse>());
 
             mocks.VerifyAll();
         }
 
-        [Test]
+        [Fact]
         public void ReadRequest()
         {
             MockRepository mocks = new MockRepository();
@@ -212,11 +208,11 @@ namespace Modbus.UnitTests.IO
 
             mocks.ReplayAll();
 
-            Assert.AreEqual(new byte[] {1, 1, 1, 0, 1, 0, 0, 5}, transport.ReadRequest());
+            Assert.Equal(new byte[] {1, 1, 1, 0, 1, 0, 0, 5}, transport.ReadRequest());
             mocks.VerifyAll();
         }
 
-        [Test]
+        [Fact]
         public void Read()
         {
             MockRepository mocks = new MockRepository();
@@ -224,22 +220,22 @@ namespace Modbus.UnitTests.IO
 
             Expect.Call(mockSerialResource.Read(new byte[5], 0, 5))
                 .Do(((Func<byte[], int, int, int>) delegate(byte[] buf, int offset, int count)
-                {
-                    Array.Copy(new byte[] {2, 2, 2}, buf, 3);
-                    return 3;
-                }));
+               {
+                   Array.Copy(new byte[] {2, 2, 2}, buf, 3);
+                   return 3;
+               }));
 
             Expect.Call(mockSerialResource.Read(new byte[] {2, 2, 2, 0, 0}, 3, 2))
                 .Do(((Func<byte[], int, int, int>) delegate(byte[] buf, int offset, int count)
-                {
-                    Array.Copy(new byte[] {3, 3}, 0, buf, 3, 2);
-                    return 2;
-                }));
+               {
+                   Array.Copy(new byte[] {3, 3}, 0, buf, 3, 2);
+                   return 2;
+               }));
 
             mocks.ReplayAll();
 
             ModbusRtuTransport transport = new ModbusRtuTransport(mockSerialResource);
-            Assert.AreEqual(new byte[] {2, 2, 2, 3, 3}, transport.Read(5));
+            Assert.Equal(new byte[] {2, 2, 2, 3, 3}, transport.Read(5));
 
             mocks.VerifyAll();
         }

--- a/NModbus4.UnitTests/IO/ModbusTcpTransportFixture.cs
+++ b/NModbus4.UnitTests/IO/ModbusTcpTransportFixture.cs
@@ -7,15 +7,13 @@ using Modbus.IO;
 using Modbus.Message;
 using Modbus.UnitTests.Message;
 using Rhino.Mocks;
+using Xunit;
 
 namespace Modbus.UnitTests.IO
 {
-    using NUnit.Framework;
-
-    [TestFixture]
     public class ModbusTcpTransportFixture
     {
-        [Test]
+        [Fact]
         public void BuildMessageFrame()
         {
             MockRepository mocks = new MockRepository();
@@ -24,20 +22,20 @@ namespace Modbus.UnitTests.IO
             ReadCoilsInputsRequest message = new ReadCoilsInputsRequest(Modbus.ReadCoils, 2, 10, 5);
             mocks.ReplayAll();
             byte[] result = mockModbusTcpTransport.BuildMessageFrame(message);
-            Assert.AreEqual(new byte[] {0, 0, 0, 0, 0, 6, 2, 1, 0, 10, 0, 5}, result);
+            Assert.Equal(new byte[] {0, 0, 0, 0, 0, 6, 2, 1, 0, 10, 0, 5}, result);
             mocks.VerifyAll();
         }
 
-        [Test]
+        [Fact]
         public void GetMbapHeader()
         {
             WriteMultipleRegistersRequest message = new WriteMultipleRegistersRequest(3, 1,
                 MessageUtility.CreateDefaultCollection<RegisterCollection, ushort>(0, 120));
             message.TransactionId = 45;
-            Assert.AreEqual(new byte[] {0, 45, 0, 0, 0, 247, 3}, ModbusIpTransport.GetMbapHeader(message));
+            Assert.Equal(new byte[] {0, 45, 0, 0, 0, 247, 3}, ModbusIpTransport.GetMbapHeader(message));
         }
 
-        [Test]
+        [Fact]
         public void Write()
         {
             MockRepository mocks = new MockRepository();
@@ -52,7 +50,7 @@ namespace Modbus.UnitTests.IO
             mocks.VerifyAll();
         }
 
-        [Test]
+        [Fact]
         public void ReadRequestResponse()
         {
             MockRepository mocks = new MockRepository();
@@ -62,27 +60,27 @@ namespace Modbus.UnitTests.IO
 
             Expect.Call(mockTransport.Read(new byte[6], 0, 6))
                 .Do(((Func<byte[], int, int, int>) delegate(byte[] buf, int offset, int count)
-                {
-                    Array.Copy(mbapHeader, buf, 6);
-                    return 6;
-                }));
+               {
+                   Array.Copy(mbapHeader, buf, 6);
+                   return 6;
+               }));
 
             ReadCoilsInputsRequest request = new ReadCoilsInputsRequest(Modbus.ReadCoils, 1, 1, 3);
 
             Expect.Call(mockTransport.Read(new byte[6], 0, 6))
                 .Do(((Func<byte[], int, int, int>) delegate(byte[] buf, int offset, int count)
-                {
-                    Array.Copy(new byte[] {1}.Concat(request.ProtocolDataUnit).ToArray(), buf, 6);
-                    return 6;
-                }));
+               {
+                   Array.Copy(new byte[] {1}.Concat(request.ProtocolDataUnit).ToArray(), buf, 6);
+                   return 6;
+               }));
 
             mocks.ReplayAll();
-            Assert.AreEqual(ModbusIpTransport.ReadRequestResponse(mockTransport),
+            Assert.Equal(ModbusIpTransport.ReadRequestResponse(mockTransport),
                 new byte[] {45, 63, 0, 0, 0, 6, 1, 1, 0, 1, 0, 3});
             mocks.VerifyAll();
         }
 
-        [Test, ExpectedException(typeof (IOException))]
+        [Fact]
         public void ReadRequestResponse_ConnectionAbortedWhileReadingMBAPHeader()
         {
             MockRepository mocks = new MockRepository();
@@ -91,11 +89,11 @@ namespace Modbus.UnitTests.IO
             Expect.Call(mockTransport.Read(new byte[6], 0, 6)).Return(0);
 
             mocks.ReplayAll();
-            ModbusIpTransport.ReadRequestResponse(mockTransport);
+            Assert.Throws<IOException>(() => ModbusIpTransport.ReadRequestResponse(mockTransport));
             mocks.VerifyAll();
         }
 
-        [Test, ExpectedException(typeof (IOException))]
+        [Fact]
         public void ReadRequestResponse_ConnectionAbortedWhileReadingMessageFrame()
         {
             MockRepository mocks = new MockRepository();
@@ -105,19 +103,19 @@ namespace Modbus.UnitTests.IO
 
             Expect.Call(mockTransport.Read(new byte[6], 0, 6))
                 .Do(((Func<byte[], int, int, int>) delegate(byte[] buf, int offset, int count)
-                {
-                    Array.Copy(mbapHeader, buf, 6);
-                    return 6;
-                }));
+               {
+                   Array.Copy(mbapHeader, buf, 6);
+                   return 6;
+               }));
 
             Expect.Call(mockTransport.Read(new byte[6], 0, 6)).Return(0);
 
             mocks.ReplayAll();
-            ModbusIpTransport.ReadRequestResponse(mockTransport);
+            Assert.Throws<IOException>(() => ModbusIpTransport.ReadRequestResponse(mockTransport));
             mocks.VerifyAll();
         }
 
-        [Test]
+        [Fact]
         public void GetNewTransactionId()
         {
             ModbusIpTransport transport = new ModbusIpTransport(MockRepository.GenerateStub<IStreamResource>());
@@ -126,11 +124,11 @@ namespace Modbus.UnitTests.IO
             for (int i = 0; i < UInt16.MaxValue; i++)
                 transactionIds.Add(transport.GetNewTransactionId(), String.Empty);
 
-            Assert.AreEqual(1, transport.GetNewTransactionId());
-            Assert.AreEqual(2, transport.GetNewTransactionId());
+            Assert.Equal(1, transport.GetNewTransactionId());
+            Assert.Equal(2, transport.GetNewTransactionId());
         }
 
-        [Test, ExpectedException(typeof (IOException))]
+        [Fact]
         public void ValidateResponse_MismatchingTransactionIds()
         {
             ModbusIpTransport transport = new ModbusIpTransport(MockRepository.GenerateStub<IStreamResource>());
@@ -140,10 +138,10 @@ namespace Modbus.UnitTests.IO
             IModbusMessage response = new ReadCoilsInputsResponse(Modbus.ReadCoils, 1, 1, null);
             response.TransactionId = 6;
 
-            transport.ValidateResponse(request, response);
+            Assert.Throws<IOException>(() => transport.ValidateResponse(request, response));
         }
 
-        [Test]
+        [Fact]
         public void ValidateResponse()
         {
             ModbusIpTransport transport = new ModbusIpTransport(MockRepository.GenerateStub<IStreamResource>());

--- a/NModbus4.UnitTests/IO/ModbusTransportFixture.cs
+++ b/NModbus4.UnitTests/IO/ModbusTransportFixture.cs
@@ -1,24 +1,20 @@
 using System;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using Modbus.Data;
 using Modbus.IO;
 using Modbus.Message;
 using Modbus.Utility;
 using Rhino.Mocks;
+using Xunit;
 
 namespace Modbus.UnitTests.IO
 {
-    using Unme.Common;
-    using NUnit.Framework;
-
     internal delegate ReadCoilsInputsResponse ThrowExceptionDelegate();
 
-    [TestFixture]
     public class ModbusTransportFixture
     {
-        [Test]
+        [Fact]
         public void UnicastMessage()
         {
             MockRepository mocks = new MockRepository();
@@ -38,12 +34,12 @@ namespace Modbus.UnitTests.IO
             ReadCoilsInputsResponse expectedResponse = new ReadCoilsInputsResponse(Modbus.ReadCoils, 2, 1,
                 new DiscreteCollection(true, false, true, false, false, false, false, false));
             ReadCoilsInputsResponse response = transport.UnicastMessage<ReadCoilsInputsResponse>(request);
-            Assert.AreEqual(expectedResponse.MessageFrame, response.MessageFrame);
+            Assert.Equal(expectedResponse.MessageFrame, response.MessageFrame);
 
             mocks.VerifyAll();
         }
 
-        [Test, ExpectedException(typeof (IOException))]
+        [Fact]
         public void UnicastMessage_WrongResponseFunctionCode()
         {
             MockRepository mocks = new MockRepository();
@@ -58,25 +54,25 @@ namespace Modbus.UnitTests.IO
             mocks.ReplayAll();
 
             ReadCoilsInputsRequest request = new ReadCoilsInputsRequest(Modbus.ReadInputs, 2, 3, 4);
-            transport.UnicastMessage<ReadCoilsInputsResponse>(request);
+            Assert.Throws<IOException>(() => transport.UnicastMessage<ReadCoilsInputsResponse>(request));
 
             mocks.VerifyAll();
         }
 
-        [Test, ExpectedException(typeof (SlaveException))]
+        [Fact]
         public void UnicastMessage_ErrorSlaveException()
         {
             MockRepository mocks = new MockRepository();
             ModbusTransport transport = mocks.PartialMock<ModbusTransport>();
             transport.Write(null);
-            LastCall.IgnoreArguments().Repeat.Times(Modbus.DefaultRetries + 1);
+            LastCall.IgnoreArguments();
             Expect.Call(transport.ReadResponse<ReadCoilsInputsResponse>())
-                .Do((ThrowExceptionDelegate) delegate { throw new SlaveException(); });
+                .Do((ThrowExceptionDelegate)delegate { throw new SlaveException(); });
 
             mocks.ReplayAll();
 
             ReadCoilsInputsRequest request = new ReadCoilsInputsRequest(Modbus.ReadInputs, 2, 3, 4);
-            transport.UnicastMessage<ReadCoilsInputsResponse>(request);
+            Assert.Throws<SlaveException>(() => transport.UnicastMessage<ReadCoilsInputsResponse>(request));
 
             mocks.VerifyAll();
         }
@@ -84,7 +80,7 @@ namespace Modbus.UnitTests.IO
         /// <summary>
         ///     We should reread the response w/o retransmitting the request.
         /// </summary>
-        [Test]
+        [Fact]
         public void UnicastMessage_AcknowlegeSlaveException()
         {
             MockRepository mocks = new MockRepository();
@@ -116,7 +112,7 @@ namespace Modbus.UnitTests.IO
                 new ReadHoldingInputRegistersResponse(Modbus.ReadHoldingRegisters, 1, new RegisterCollection(1));
             ReadHoldingInputRegistersResponse response =
                 transport.UnicastMessage<ReadHoldingInputRegistersResponse>(request);
-            Assert.AreEqual(expectedResponse.MessageFrame, response.MessageFrame);
+            Assert.Equal(expectedResponse.MessageFrame, response.MessageFrame);
 
             mocks.VerifyAll();
         }
@@ -124,7 +120,7 @@ namespace Modbus.UnitTests.IO
         /// <summary>
         ///     We should retransmit the request.
         /// </summary>
-        [Test]
+        [Fact]
         public void UnicastMessage_SlaveDeviceBusySlaveException()
         {
             MockRepository mocks = new MockRepository();
@@ -156,7 +152,7 @@ namespace Modbus.UnitTests.IO
                 new ReadHoldingInputRegistersResponse(Modbus.ReadHoldingRegisters, 1, new RegisterCollection(1));
             ReadHoldingInputRegistersResponse response =
                 transport.UnicastMessage<ReadHoldingInputRegistersResponse>(request);
-            Assert.AreEqual(expectedResponse.MessageFrame, response.MessageFrame);
+            Assert.Equal(expectedResponse.MessageFrame, response.MessageFrame);
 
             mocks.VerifyAll();
         }
@@ -164,7 +160,7 @@ namespace Modbus.UnitTests.IO
         /// <summary>
         ///     We should retransmit the request.
         /// </summary>
-        [Test]
+        [Fact]
         public void UnicastMessage_SlaveDeviceBusySlaveExceptionDoesNotFailAfterExceedingRetries()
         {
             MockRepository mocks = new MockRepository();
@@ -197,16 +193,16 @@ namespace Modbus.UnitTests.IO
                 new ReadHoldingInputRegistersResponse(Modbus.ReadHoldingRegisters, 1, new RegisterCollection(1));
             ReadHoldingInputRegistersResponse response =
                 transport.UnicastMessage<ReadHoldingInputRegistersResponse>(request);
-            Assert.AreEqual(expectedResponse.MessageFrame, response.MessageFrame);
+            Assert.Equal(expectedResponse.MessageFrame, response.MessageFrame);
 
             mocks.VerifyAll();
         }
 
-        [
-            TestCase(typeof (TimeoutException)),
-            TestCase(typeof (IOException)),
-            TestCase(typeof (NotImplementedException)),
-            TestCase(typeof (FormatException))]
+        [Theory,
+            InlineData(typeof (TimeoutException)),
+            InlineData(typeof (IOException)),
+            InlineData(typeof (NotImplementedException)),
+            InlineData(typeof (FormatException))]
         public void UnicastMessage_SingleFailingException(Type exceptionType)
         {
             MockRepository mocks = new MockRepository();
@@ -232,10 +228,11 @@ namespace Modbus.UnitTests.IO
             mocks.VerifyAll();
         }
 
-        [TestCase(typeof (TimeoutException)),
-         TestCase(typeof (IOException)),
-         TestCase(typeof (NotImplementedException)),
-         TestCase(typeof (FormatException))]
+        [Theory,
+            InlineData(typeof (TimeoutException)),
+            InlineData(typeof (IOException)),
+            InlineData(typeof (NotImplementedException)),
+            InlineData(typeof (FormatException))]
         public void UnicastMessage_TooManyFailingExceptions(Type exceptionType)
         {
             MockRepository mocks = new MockRepository();
@@ -245,7 +242,7 @@ namespace Modbus.UnitTests.IO
             LastCall.IgnoreArguments().Repeat.Times(transport.Retries + 1);
 
             Expect.Call(transport.ReadResponse<ReadCoilsInputsResponse>())
-                .Do((ThrowExceptionDelegate) delegate { throw (Exception) Activator.CreateInstance(exceptionType); })
+                .Do((ThrowExceptionDelegate)delegate { throw (Exception)Activator.CreateInstance(exceptionType); })
                 .Repeat.Times(transport.Retries + 1);
 
             mocks.ReplayAll();
@@ -257,7 +254,7 @@ namespace Modbus.UnitTests.IO
             mocks.VerifyAll();
         }
 
-        [Test, ExpectedException(typeof (TimeoutException))]
+        [Fact]
         public void UnicastMessage_TimeoutException()
         {
             MockRepository mocks = new MockRepository();
@@ -265,18 +262,18 @@ namespace Modbus.UnitTests.IO
             transport.Write(null);
             LastCall.IgnoreArguments().Repeat.Times(Modbus.DefaultRetries + 1);
             Expect.Call(transport.ReadResponse<ReadCoilsInputsResponse>())
-                .Do((ThrowExceptionDelegate) delegate { throw new TimeoutException(); })
+                .Do((ThrowExceptionDelegate) delegate{ throw new TimeoutException(); })
                 .Repeat.Times(Modbus.DefaultRetries + 1);
 
             mocks.ReplayAll();
 
             ReadCoilsInputsRequest request = new ReadCoilsInputsRequest(Modbus.ReadInputs, 2, 3, 4);
-            transport.UnicastMessage<ReadCoilsInputsResponse>(request);
+            Assert.Throws<TimeoutException>(() => transport.UnicastMessage<ReadCoilsInputsResponse>(request));
 
             mocks.VerifyAll();
         }
 
-        [Test, ExpectedException(typeof (TimeoutException))]
+        [Fact]
         public void UnicastMessage_Retries()
         {
             MockRepository mocks = new MockRepository();
@@ -285,18 +282,18 @@ namespace Modbus.UnitTests.IO
             transport.Write(null);
             LastCall.IgnoreArguments().Repeat.Times(transport.Retries + 1);
             Expect.Call(transport.ReadResponse<ReadCoilsInputsResponse>())
-                .Do((ThrowExceptionDelegate) delegate { throw new TimeoutException(); })
+                .Do((ThrowExceptionDelegate) delegate{ throw new TimeoutException(); })
                 .Repeat.Times(transport.Retries + 1);
 
             mocks.ReplayAll();
 
             ReadCoilsInputsRequest request = new ReadCoilsInputsRequest(Modbus.ReadInputs, 2, 3, 4);
-            transport.UnicastMessage<ReadCoilsInputsResponse>(request);
+            Assert.Throws<TimeoutException>(() => transport.UnicastMessage<ReadCoilsInputsResponse>(request));
 
             mocks.VerifyAll();
         }
 
-        [Test]
+        [Fact]
         public void CreateResponse_SlaveException()
         {
             ModbusTransport transport = new ModbusAsciiTransport(MockRepository.GenerateStub<IStreamResource>());
@@ -305,10 +302,10 @@ namespace Modbus.UnitTests.IO
             IModbusMessage message =
                 transport.CreateResponse<ReadCoilsInputsResponse>(
                     Enumerable.Concat(frame, new byte[] { lrc }).ToArray());
-            Assert.IsTrue(message is SlaveExceptionResponse);
+            Assert.True(message is SlaveExceptionResponse);
         }
 
-        [Test, ExpectedException(typeof (IOException))]
+        [Fact]
         public void ValidateResponse_MismatchingFunctionCodes()
         {
             MockRepository mocks = new MockRepository();
@@ -319,11 +316,11 @@ namespace Modbus.UnitTests.IO
                 new RegisterCollection());
 
             mocks.ReplayAll();
-            transport.ValidateResponse(request, response);
+            Assert.Throws<IOException>(() => transport.ValidateResponse(request, response));
             mocks.VerifyAll();
         }
 
-        [Test]
+        [Fact]
         public void ValidateResponse()
         {
             MockRepository mocks = new MockRepository();

--- a/NModbus4.UnitTests/IO/UdpClientAdapterFixture.cs
+++ b/NModbus4.UnitTests/IO/UdpClientAdapterFixture.cs
@@ -1,15 +1,13 @@
 ﻿using System;
 using System.Net.Sockets;
 using Modbus.IO;
+using Xunit;
 
 namespace Modbus.UnitTests.IO
 {
-    using NUnit.Framework;
-
-    [TestFixture]
     public class UdpClientAdapterFixture
     {
-        [Test]
+        [Fact]
         public void Read_ArgumentValidation()
         {
             var adapter = new UdpClientAdapter(new UdpClient());
@@ -25,7 +23,7 @@ namespace Modbus.UnitTests.IO
             Assert.Throws<ArgumentOutOfRangeException>(() => adapter.Read(new byte[2], 1, 2));
         }
 
-        [Test]
+        [Fact]
         public void Write_ArgumentValidation()
         {
             var adapter = new UdpClientAdapter(new UdpClient());

--- a/NModbus4.UnitTests/Message/DiagnosticsRequestResponseFixture.cs
+++ b/NModbus4.UnitTests/Message/DiagnosticsRequestResponseFixture.cs
@@ -1,19 +1,17 @@
 ﻿using Modbus.Data;
 using Modbus.Message;
+using Xunit;
 
 namespace Modbus.UnitTests.Message
 {
-    using NUnit.Framework;
-
-    [TestFixture]
     public class DiagnosticsRequestResponseFixture
     {
-        [Test]
+        [Fact]
         public void ToString_Test()
         {
             var message = new DiagnosticsRequestResponse(Modbus.DiagnosticsReturnQueryData, 3, new RegisterCollection(5));
 
-            Assert.AreEqual("Diagnostics message, sub-function return query data - {5}.", message.ToString());
+            Assert.Equal("Diagnostics message, sub-function return query data - {5}.", message.ToString());
         }
     }
 }

--- a/NModbus4.UnitTests/Message/ModbusMessageFactoryFixture.cs
+++ b/NModbus4.UnitTests/Message/ModbusMessageFactoryFixture.cs
@@ -2,16 +2,13 @@ using System;
 using System.Linq;
 using Modbus.Data;
 using Modbus.Message;
+using Xunit;
 
 namespace Modbus.UnitTests.Message
 {
-    using Unme.Common;
-    using NUnit.Framework;
-
-    [TestFixture]
     public class ModbusMessageFactoryFixture : ModbusMessageFixture
     {
-        [Test]
+        [Fact]
         public void CreateModbusMessageReadCoilsRequest()
         {
             ReadCoilsInputsRequest request =
@@ -19,20 +16,18 @@ namespace Modbus.UnitTests.Message
                 {11, Modbus.ReadCoils, 0, 19, 0, 37});
             ReadCoilsInputsRequest expectedRequest = new ReadCoilsInputsRequest(Modbus.ReadCoils, 11, 19, 37);
             AssertModbusMessagePropertiesAreEqual(request, expectedRequest);
-            Assert.AreEqual(expectedRequest.StartAddress, request.StartAddress);
-            Assert.AreEqual(expectedRequest.NumberOfPoints, request.NumberOfPoints);
+            Assert.Equal(expectedRequest.StartAddress, request.StartAddress);
+            Assert.Equal(expectedRequest.NumberOfPoints, request.NumberOfPoints);
         }
 
-        [Test]
-        [ExpectedException(typeof (FormatException))]
+        [Fact]
         public void CreateModbusMessageReadCoilsRequestWithInvalidFrameSize()
         {
             byte[] frame = {11, Modbus.ReadCoils, 4, 1, 2};
-            ReadCoilsInputsRequest request = ModbusMessageFactory.CreateModbusMessage<ReadCoilsInputsRequest>(frame);
-            Assert.Fail();
+            Assert.Throws<FormatException>(() => ModbusMessageFactory.CreateModbusMessage<ReadCoilsInputsRequest>(frame));
         }
 
-        [Test]
+        [Fact]
         public void CreateModbusMessageReadCoilsResponse()
         {
             ReadCoilsInputsResponse response =
@@ -41,28 +36,24 @@ namespace Modbus.UnitTests.Message
             ReadCoilsInputsResponse expectedResponse = new ReadCoilsInputsResponse(Modbus.ReadCoils, 11, 1,
                 new DiscreteCollection(true, false, false, false));
             AssertModbusMessagePropertiesAreEqual(expectedResponse, response);
-            Assert.AreEqual(expectedResponse.Data.NetworkBytes, response.Data.NetworkBytes);
+            Assert.Equal(expectedResponse.Data.NetworkBytes, response.Data.NetworkBytes);
         }
 
-        [Test]
-        [ExpectedException(typeof (FormatException))]
+        [Fact]
         public void CreateModbusMessageReadCoilsResponseWithNoByteCount()
         {
             byte[] frame = {11, Modbus.ReadCoils};
-            ReadCoilsInputsResponse response = ModbusMessageFactory.CreateModbusMessage<ReadCoilsInputsResponse>(frame);
-            Assert.Fail();
+            Assert.Throws<FormatException>(() => ModbusMessageFactory.CreateModbusMessage<ReadCoilsInputsResponse>(frame));
         }
 
-        [Test]
-        [ExpectedException(typeof (FormatException))]
+        [Fact]
         public void CreateModbusMessageReadCoilsResponseWithInvalidDataSize()
         {
             byte[] frame = {11, Modbus.ReadCoils, 4, 1, 2, 3};
-            ReadCoilsInputsResponse response = ModbusMessageFactory.CreateModbusMessage<ReadCoilsInputsResponse>(frame);
-            Assert.Fail();
+            Assert.Throws<FormatException>(() => ModbusMessageFactory.CreateModbusMessage<ReadCoilsInputsResponse>(frame));
         }
 
-        [Test]
+        [Fact]
         public void CreateModbusMessageReadHoldingRegistersRequest()
         {
             ReadHoldingInputRegistersRequest request =
@@ -71,20 +62,19 @@ namespace Modbus.UnitTests.Message
             ReadHoldingInputRegistersRequest expectedRequest =
                 new ReadHoldingInputRegistersRequest(Modbus.ReadHoldingRegisters, 17, 107, 3);
             AssertModbusMessagePropertiesAreEqual(expectedRequest, request);
-            Assert.AreEqual(expectedRequest.StartAddress, request.StartAddress);
-            Assert.AreEqual(expectedRequest.NumberOfPoints, request.NumberOfPoints);
+            Assert.Equal(expectedRequest.StartAddress, request.StartAddress);
+            Assert.Equal(expectedRequest.NumberOfPoints, request.NumberOfPoints);
         }
 
-        [Test]
-        [ExpectedException(typeof (FormatException))]
+        [Fact]
         public void CreateModbusMessageReadHoldingRegistersRequestWithInvalidFrameSize()
         {
-            ReadHoldingInputRegistersRequest request =
+            Assert.Throws<FormatException>(() =>
                 ModbusMessageFactory.CreateModbusMessage<ReadHoldingInputRegistersRequest>(new byte[]
-                {11, Modbus.ReadHoldingRegisters, 0, 0, 5});
+                {11, Modbus.ReadHoldingRegisters, 0, 0, 5}));
         }
 
-        [Test]
+        [Fact]
         public void CreateModbusMessageReadHoldingRegistersResponse()
         {
             ReadHoldingInputRegistersResponse response =
@@ -95,44 +85,40 @@ namespace Modbus.UnitTests.Message
             AssertModbusMessagePropertiesAreEqual(expectedResponse, response);
         }
 
-        [Test]
-        [ExpectedException(typeof (FormatException))]
+        [Fact]
         public void CreateModbusMessageReadHoldingRegistersResponseWithInvalidFrameSize()
         {
-            ModbusMessageFactory.CreateModbusMessage<ReadHoldingInputRegistersResponse>(new byte[]
-            {11, Modbus.ReadHoldingRegisters});
+            Assert.Throws<FormatException>(() => ModbusMessageFactory.CreateModbusMessage<ReadHoldingInputRegistersResponse>(new byte[]
+                {11, Modbus.ReadHoldingRegisters}));
         }
 
-        [Test]
+        [Fact]
         public void CreateModbusMessageSlaveExceptionResponse()
         {
             SlaveExceptionResponse response =
                 ModbusMessageFactory.CreateModbusMessage<SlaveExceptionResponse>(new byte[] {11, 129, 2});
             SlaveExceptionResponse expectedException = new SlaveExceptionResponse(11,
                 Modbus.ReadCoils + Modbus.ExceptionOffset, 2);
-            Assert.AreEqual(expectedException.FunctionCode, response.FunctionCode);
-            Assert.AreEqual(expectedException.SlaveAddress, response.SlaveAddress);
-            Assert.AreEqual(expectedException.MessageFrame, response.MessageFrame);
-            Assert.AreEqual(expectedException.ProtocolDataUnit, response.ProtocolDataUnit);
+            Assert.Equal(expectedException.FunctionCode, response.FunctionCode);
+            Assert.Equal(expectedException.SlaveAddress, response.SlaveAddress);
+            Assert.Equal(expectedException.MessageFrame, response.MessageFrame);
+            Assert.Equal(expectedException.ProtocolDataUnit, response.ProtocolDataUnit);
         }
 
-        [Test]
-        [ExpectedException(typeof (FormatException))]
+        [Fact]
         public void CreateModbusMessageSlaveExceptionResponseWithInvalidFunctionCode()
         {
-            SlaveExceptionResponse response =
-                ModbusMessageFactory.CreateModbusMessage<SlaveExceptionResponse>(new byte[] {11, 128, 2});
+            Assert.Throws<FormatException>(() =>
+                ModbusMessageFactory.CreateModbusMessage<SlaveExceptionResponse>(new byte[] {11, 128, 2}));
         }
 
-        [Test]
-        [ExpectedException(typeof (FormatException))]
+        [Fact]
         public void CreateModbusMessageSlaveExceptionResponseWithInvalidFrameSize()
         {
-            ModbusMessageFactory.CreateModbusMessage<SlaveExceptionResponse>(new byte[] {11, 128});
-            Assert.Fail();
+            Assert.Throws<FormatException>(() => ModbusMessageFactory.CreateModbusMessage<SlaveExceptionResponse>(new byte[] {11, 128}));
         }
 
-        [Test]
+        [Fact]
         public void CreateModbusMessageWriteSingleCoilRequestResponse()
         {
             WriteSingleCoilRequestResponse request =
@@ -140,21 +126,19 @@ namespace Modbus.UnitTests.Message
                 {17, Modbus.WriteSingleCoil, 0, 172, byte.MaxValue, 0});
             WriteSingleCoilRequestResponse expectedRequest = new WriteSingleCoilRequestResponse(17, 172, true);
             AssertModbusMessagePropertiesAreEqual(expectedRequest, request);
-            Assert.AreEqual(expectedRequest.StartAddress, request.StartAddress);
-            Assert.AreEqual(expectedRequest.Data.NetworkBytes, request.Data.NetworkBytes);
+            Assert.Equal(expectedRequest.StartAddress, request.StartAddress);
+            Assert.Equal(expectedRequest.Data.NetworkBytes, request.Data.NetworkBytes);
         }
 
-        [Test]
-        [ExpectedException(typeof (FormatException))]
+        [Fact]
         public void CreateModbusMessageWriteSingleCoilRequestResponseWithInvalidFrameSize()
         {
-            WriteSingleCoilRequestResponse request =
+            Assert.Throws<FormatException>(() =>
                 ModbusMessageFactory.CreateModbusMessage<WriteSingleCoilRequestResponse>(new byte[]
-                {11, Modbus.WriteSingleCoil, 0, 105, byte.MaxValue});
-            Assert.Fail();
+                {11, Modbus.WriteSingleCoil, 0, 105, byte.MaxValue}));
         }
 
-        [Test]
+        [Fact]
         public void CreateModbusMessageWriteSingleRegisterRequestResponse()
         {
             WriteSingleRegisterRequestResponse request =
@@ -162,21 +146,19 @@ namespace Modbus.UnitTests.Message
                 {17, Modbus.WriteSingleRegister, 0, 1, 0, 3});
             WriteSingleRegisterRequestResponse expectedRequest = new WriteSingleRegisterRequestResponse(17, 1, 3);
             AssertModbusMessagePropertiesAreEqual(expectedRequest, request);
-            Assert.AreEqual(expectedRequest.StartAddress, request.StartAddress);
-            Assert.AreEqual(expectedRequest.Data.NetworkBytes, request.Data.NetworkBytes);
+            Assert.Equal(expectedRequest.StartAddress, request.StartAddress);
+            Assert.Equal(expectedRequest.Data.NetworkBytes, request.Data.NetworkBytes);
         }
 
-        [Test]
-        [ExpectedException(typeof (FormatException))]
+        [Fact]
         public void CreateModbusMessageWriteSingleRegisterRequestResponseWithInvalidFrameSize()
         {
-            WriteSingleRegisterRequestResponse request =
+            Assert.Throws<FormatException>(() =>
                 ModbusMessageFactory.CreateModbusMessage<WriteSingleRegisterRequestResponse>(new byte[]
-                {11, Modbus.WriteSingleRegister, 0, 1, 0});
-            Assert.Fail();
+                {11, Modbus.WriteSingleRegister, 0, 1, 0}));
         }
 
-        [Test]
+        [Fact]
         public void CreateModbusMessageWriteMultipleRegistersRequest()
         {
             WriteMultipleRegistersRequest request =
@@ -185,23 +167,21 @@ namespace Modbus.UnitTests.Message
             WriteMultipleRegistersRequest expectedRequest = new WriteMultipleRegistersRequest(11, 5,
                 new RegisterCollection(ushort.MaxValue));
             AssertModbusMessagePropertiesAreEqual(expectedRequest, request);
-            Assert.AreEqual(expectedRequest.StartAddress, request.StartAddress);
-            Assert.AreEqual(expectedRequest.NumberOfPoints, request.NumberOfPoints);
-            Assert.AreEqual(expectedRequest.ByteCount, request.ByteCount);
-            Assert.AreEqual(expectedRequest.Data.NetworkBytes, request.Data.NetworkBytes);
+            Assert.Equal(expectedRequest.StartAddress, request.StartAddress);
+            Assert.Equal(expectedRequest.NumberOfPoints, request.NumberOfPoints);
+            Assert.Equal(expectedRequest.ByteCount, request.ByteCount);
+            Assert.Equal(expectedRequest.Data.NetworkBytes, request.Data.NetworkBytes);
         }
 
-        [Test]
-        [ExpectedException(typeof (FormatException))]
+        [Fact]
         public void CreateModbusMessageWriteMultipleRegistersRequestWithInvalidFrameSize()
         {
-            WriteMultipleRegistersRequest request =
+            Assert.Throws<FormatException>(() =>
                 ModbusMessageFactory.CreateModbusMessage<WriteMultipleRegistersRequest>(new byte[]
-                {11, Modbus.WriteMultipleRegisters, 0, 5, 0, 1, 2});
-            Assert.Fail();
+                {11, Modbus.WriteMultipleRegisters, 0, 5, 0, 1, 2}));
         }
 
-        [Test]
+        [Fact]
         public void CreateModbusMessageWriteMultipleRegistersResponse()
         {
             WriteMultipleRegistersResponse response =
@@ -209,11 +189,11 @@ namespace Modbus.UnitTests.Message
                 {17, Modbus.WriteMultipleRegisters, 0, 1, 0, 2});
             WriteMultipleRegistersResponse expectedResponse = new WriteMultipleRegistersResponse(17, 1, 2);
             AssertModbusMessagePropertiesAreEqual(expectedResponse, response);
-            Assert.AreEqual(expectedResponse.StartAddress, response.StartAddress);
-            Assert.AreEqual(expectedResponse.NumberOfPoints, response.NumberOfPoints);
+            Assert.Equal(expectedResponse.StartAddress, response.StartAddress);
+            Assert.Equal(expectedResponse.NumberOfPoints, response.NumberOfPoints);
         }
 
-        [Test]
+        [Fact]
         public void CreateModbusMessageWriteMultipleCoilsRequest()
         {
             WriteMultipleCoilsRequest request =
@@ -222,23 +202,21 @@ namespace Modbus.UnitTests.Message
             WriteMultipleCoilsRequest expectedRequest = new WriteMultipleCoilsRequest(17, 19,
                 new DiscreteCollection(true, false, true, true, false, false, true, true, true, false));
             AssertModbusMessagePropertiesAreEqual(expectedRequest, request);
-            Assert.AreEqual(expectedRequest.StartAddress, request.StartAddress);
-            Assert.AreEqual(expectedRequest.NumberOfPoints, request.NumberOfPoints);
-            Assert.AreEqual(expectedRequest.ByteCount, request.ByteCount);
-            Assert.AreEqual(expectedRequest.Data.NetworkBytes, request.Data.NetworkBytes);
+            Assert.Equal(expectedRequest.StartAddress, request.StartAddress);
+            Assert.Equal(expectedRequest.NumberOfPoints, request.NumberOfPoints);
+            Assert.Equal(expectedRequest.ByteCount, request.ByteCount);
+            Assert.Equal(expectedRequest.Data.NetworkBytes, request.Data.NetworkBytes);
         }
 
-        [Test]
-        [ExpectedException(typeof (FormatException))]
+        [Fact]
         public void CreateModbusMessageWriteMultipleCoilsRequestWithInvalidFrameSize()
         {
-            WriteMultipleCoilsRequest request =
+            Assert.Throws<FormatException>(() =>
                 ModbusMessageFactory.CreateModbusMessage<WriteMultipleCoilsRequest>(new byte[]
-                {17, Modbus.WriteMultipleCoils, 0, 19, 0, 10, 2});
-            Assert.Fail();
+                {17, Modbus.WriteMultipleCoils, 0, 19, 0, 10, 2}));
         }
 
-        [Test]
+        [Fact]
         public void CreateModbusMessageWriteMultipleCoilsResponse()
         {
             WriteMultipleCoilsResponse response =
@@ -246,21 +224,19 @@ namespace Modbus.UnitTests.Message
                 {17, Modbus.WriteMultipleCoils, 0, 19, 0, 10});
             WriteMultipleCoilsResponse expectedResponse = new WriteMultipleCoilsResponse(17, 19, 10);
             AssertModbusMessagePropertiesAreEqual(expectedResponse, response);
-            Assert.AreEqual(expectedResponse.StartAddress, response.StartAddress);
-            Assert.AreEqual(expectedResponse.NumberOfPoints, response.NumberOfPoints);
+            Assert.Equal(expectedResponse.StartAddress, response.StartAddress);
+            Assert.Equal(expectedResponse.NumberOfPoints, response.NumberOfPoints);
         }
 
-        [Test]
-        [ExpectedException(typeof (FormatException))]
+        [Fact]
         public void CreateModbusMessageWriteMultipleCoilsResponseWithInvalidFrameSize()
         {
-            WriteMultipleCoilsResponse request =
+            Assert.Throws<FormatException>(() =>
                 ModbusMessageFactory.CreateModbusMessage<WriteMultipleCoilsResponse>(new byte[]
-                {17, Modbus.WriteMultipleCoils, 0, 19, 0});
-            Assert.Fail();
+                {17, Modbus.WriteMultipleCoils, 0, 19, 0}));
         }
 
-        [Test]
+        [Fact]
         public void CreateModbusMessageReadWriteMultipleRegistersRequest()
         {
             ReadWriteMultipleRegistersRequest request =
@@ -272,69 +248,64 @@ namespace Modbus.UnitTests.Message
             AssertModbusMessagePropertiesAreEqual(expectedRequest, request);
         }
 
-        [Test]
-        [ExpectedException(typeof (FormatException))]
+        [Fact]
         public void CreateModbusMessageReadWriteMultipleRegistersRequestWithInvalidFrameSize()
         {
             byte[] frame = {17, Modbus.ReadWriteMultipleRegisters, 1, 2, 3};
-            ReadWriteMultipleRegistersRequest request =
-                ModbusMessageFactory.CreateModbusMessage<ReadWriteMultipleRegistersRequest>(frame);
-            Assert.Fail();
+            Assert.Throws<FormatException>(() =>
+                ModbusMessageFactory.CreateModbusMessage<ReadWriteMultipleRegistersRequest>(frame));
         }
 
-        [Test]
+        [Fact]
         public void CreateModbusMessageReturnQueryDataRequestResponse()
         {
             const byte slaveAddress = 5;
             RegisterCollection data = new RegisterCollection(50);
-            byte[] frame = new byte[] { slaveAddress, 8, 0, 0 }.Concat(data.NetworkBytes).ToArray();
+            byte[] frame = new byte[] {slaveAddress, 8, 0, 0}.Concat(data.NetworkBytes).ToArray();
             DiagnosticsRequestResponse message =
                 ModbusMessageFactory.CreateModbusMessage<DiagnosticsRequestResponse>(frame);
             DiagnosticsRequestResponse expectedMessage =
                 new DiagnosticsRequestResponse(Modbus.DiagnosticsReturnQueryData, slaveAddress, data);
 
-            Assert.AreEqual(expectedMessage.SubFunctionCode, message.SubFunctionCode);
+            Assert.Equal(expectedMessage.SubFunctionCode, message.SubFunctionCode);
             AssertModbusMessagePropertiesAreEqual(expectedMessage, message);
         }
 
-        [Test]
-        [ExpectedException(typeof (FormatException))]
+        [Fact]
         public void CreateModbusMessageReturnQueryDataRequestResponseTooSmall()
         {
             byte[] frame = new byte[] {5, 8, 0, 0, 5};
-            DiagnosticsRequestResponse message =
-                ModbusMessageFactory.CreateModbusMessage<DiagnosticsRequestResponse>(frame);
+            Assert.Throws<FormatException>(() =>
+                ModbusMessageFactory.CreateModbusMessage<DiagnosticsRequestResponse>(frame));
         }
 
-        [Test, ExpectedException(typeof (FormatException))]
+        [Fact]
         public void CreateModbusRequestWithInvalidMessageFrame()
         {
-            ModbusMessageFactory.CreateModbusRequest(new byte[] {0, 1});
-            Assert.Fail();
+            Assert.Throws<FormatException>(() => ModbusMessageFactory.CreateModbusRequest(new byte[] { 0, 1 }));
         }
 
-        [Test, ExpectedException(typeof (ArgumentException))]
+        [Fact]
         public void CreateModbusRequestWithInvalidFunctionCode()
         {
-            ModbusMessageFactory.CreateModbusRequest(new byte[] {1, 99, 0, 0, 0, 1, 23});
-            Assert.Fail();
+            Assert.Throws<ArgumentException>(() => ModbusMessageFactory.CreateModbusRequest(new byte[] { 1, 99, 0, 0, 0, 1, 23 }));
         }
 
-        [Test]
+        [Fact]
         public void CreateModbusRequestForReadCoils()
         {
             ReadCoilsInputsRequest req = new ReadCoilsInputsRequest(1, 2, 1, 10);
             IModbusMessage request = ModbusMessageFactory.CreateModbusRequest(req.MessageFrame);
-            Assert.AreEqual(typeof (ReadCoilsInputsRequest), request.GetType());
+            Assert.Equal(typeof (ReadCoilsInputsRequest), request.GetType());
         }
 
-        [Test]
+        [Fact]
         public void CreateModbusRequestForDiagnostics()
         {
             DiagnosticsRequestResponse diagnosticsRequest = new DiagnosticsRequestResponse(0, 2,
                 new RegisterCollection(45));
             IModbusMessage request = ModbusMessageFactory.CreateModbusRequest(diagnosticsRequest.MessageFrame);
-            Assert.AreEqual(typeof (DiagnosticsRequestResponse), request.GetType());
+            Assert.Equal(typeof (DiagnosticsRequestResponse), request.GetType());
         }
     }
 }

--- a/NModbus4.UnitTests/Message/ModbusMessageFixture.cs
+++ b/NModbus4.UnitTests/Message/ModbusMessageFixture.cs
@@ -2,31 +2,29 @@ using System;
 using System.Linq;
 using System.Reflection;
 using Modbus.Message;
+using Xunit;
 
 namespace Modbus.UnitTests.Message
 {
-    using NUnit.Framework;
-
-    [TestFixture]
     public class ModbusMessageFixture
     {
-        [Test]
+        [Fact]
         public void ProtocolDataUnitReadCoilsRequest()
         {
             AbstractModbusMessage message = new ReadCoilsInputsRequest(Modbus.ReadCoils, 1, 100, 9);
             byte[] expectedResult = {Modbus.ReadCoils, 0, 100, 0, 9};
-            Assert.AreEqual(expectedResult, message.ProtocolDataUnit);
+            Assert.Equal(expectedResult, message.ProtocolDataUnit);
         }
 
-        [Test]
+        [Fact]
         public void MessageFrameReadCoilsRequest()
         {
             AbstractModbusMessage message = new ReadCoilsInputsRequest(Modbus.ReadCoils, 1, 2, 3);
             byte[] expectedMessageFrame = {1, Modbus.ReadCoils, 0, 2, 0, 3};
-            Assert.AreEqual(expectedMessageFrame, message.MessageFrame);
+            Assert.Equal(expectedMessageFrame, message.MessageFrame);
         }
 
-        [Test]
+        [Fact]
         public void ModbusMessageToStringOverriden()
         {
             var messageTypes = from message in typeof (AbstractModbusMessage).Assembly.GetTypes()
@@ -34,18 +32,19 @@ namespace Modbus.UnitTests.Message
                 select message;
 
             foreach (Type messageType in messageTypes)
-                Assert.IsNotNull(
+            {
+                Assert.NotNull(
                     messageType.GetMethod("ToString",
-                        BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly),
-                    String.Concat("No ToString override in message ", messageType.FullName));
+                        BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly));
+            }
         }
 
         internal static void AssertModbusMessagePropertiesAreEqual(IModbusMessage obj1, IModbusMessage obj2)
         {
-            Assert.AreEqual(obj1.FunctionCode, obj2.FunctionCode);
-            Assert.AreEqual(obj1.SlaveAddress, obj2.SlaveAddress);
-            Assert.AreEqual(obj1.MessageFrame, obj2.MessageFrame);
-            Assert.AreEqual(obj1.ProtocolDataUnit, obj2.ProtocolDataUnit);
+            Assert.Equal(obj1.FunctionCode, obj2.FunctionCode);
+            Assert.Equal(obj1.SlaveAddress, obj2.SlaveAddress);
+            Assert.Equal(obj1.MessageFrame, obj2.MessageFrame);
+            Assert.Equal(obj1.ProtocolDataUnit, obj2.ProtocolDataUnit);
         }
     }
 }

--- a/NModbus4.UnitTests/Message/ModbusMessageImplFixture.cs
+++ b/NModbus4.UnitTests/Message/ModbusMessageImplFixture.cs
@@ -1,59 +1,56 @@
 using System;
 using Modbus.Message;
+using Xunit;
 
 namespace Modbus.UnitTests.Message
 {
-    using NUnit.Framework;
-
-    [TestFixture]
     public class ModbusMessageImplFixture
     {
-        [Test]
+        [Fact]
         public void ModbusMessageCtorInitializesProperties()
         {
             ModbusMessageImpl messageImpl = new ModbusMessageImpl(5, Modbus.ReadCoils);
-            Assert.AreEqual(5, messageImpl.SlaveAddress);
-            Assert.AreEqual(Modbus.ReadCoils, messageImpl.FunctionCode);
+            Assert.Equal(5, messageImpl.SlaveAddress);
+            Assert.Equal(Modbus.ReadCoils, messageImpl.FunctionCode);
         }
 
-        [Test]
+        [Fact]
         public void Initialize()
         {
             ModbusMessageImpl messageImpl = new ModbusMessageImpl();
             messageImpl.Initialize(new byte[] {1, 2, 9, 9, 9, 9});
-            Assert.AreEqual(1, messageImpl.SlaveAddress);
-            Assert.AreEqual(2, messageImpl.FunctionCode);
+            Assert.Equal(1, messageImpl.SlaveAddress);
+            Assert.Equal(2, messageImpl.FunctionCode);
         }
 
-        [Test, ExpectedException(typeof (ArgumentNullException))]
+        [Fact]
         public void ChecckInitializeFrameNull()
         {
             ModbusMessageImpl messageImpl = new ModbusMessageImpl();
-            messageImpl.Initialize(null);
+            Assert.Throws<ArgumentNullException>(() => messageImpl.Initialize(null));
         }
 
-        [Test]
-        [ExpectedException(typeof (FormatException))]
+        [Fact]
         public void InitializeInvalidFrame()
         {
             ModbusMessageImpl messageImpl = new ModbusMessageImpl();
-            messageImpl.Initialize(new byte[] {1});
+            Assert.Throws<FormatException>(() => messageImpl.Initialize(new byte[] {1}));
         }
 
-        [Test]
+        [Fact]
         public void ProtocolDataUnit()
         {
             ModbusMessageImpl messageImpl = new ModbusMessageImpl(11, Modbus.ReadCoils);
             byte[] expectedResult = {Modbus.ReadCoils};
-            Assert.AreEqual(expectedResult, messageImpl.ProtocolDataUnit);
+            Assert.Equal(expectedResult, messageImpl.ProtocolDataUnit);
         }
 
-        [Test]
+        [Fact]
         public void MessageFrame()
         {
             ModbusMessageImpl messageImpl = new ModbusMessageImpl(11, Modbus.ReadHoldingRegisters);
             byte[] expectedMessageFrame = {11, Modbus.ReadHoldingRegisters};
-            Assert.AreEqual(expectedMessageFrame, messageImpl.MessageFrame);
+            Assert.Equal(expectedMessageFrame, messageImpl.MessageFrame);
         }
     }
 }

--- a/NModbus4.UnitTests/Message/ModbusMessageWithDataFixture.cs
+++ b/NModbus4.UnitTests/Message/ModbusMessageWithDataFixture.cs
@@ -1,39 +1,37 @@
 using Modbus.Data;
 using Modbus.Message;
+using Xunit;
 
 namespace Modbus.UnitTests.Message
 {
-    using NUnit.Framework;
-
-    [TestFixture]
     public class ModbusMessageWithDataFixture
     {
-        [Test]
+        [Fact]
         public void ModbusMessageWithDataFixtureCtorInitializesProperties()
         {
             AbstractModbusMessageWithData<DiscreteCollection> message = new ReadCoilsInputsResponse(Modbus.ReadCoils, 10, 1,
                 new DiscreteCollection(true, false, true));
-            Assert.AreEqual(Modbus.ReadCoils, message.FunctionCode);
-            Assert.AreEqual(10, message.SlaveAddress);
+            Assert.Equal(Modbus.ReadCoils, message.FunctionCode);
+            Assert.Equal(10, message.SlaveAddress);
         }
 
-        [Test]
+        [Fact]
         public void ProtocolDataUnitReadCoilsResponse()
         {
             AbstractModbusMessageWithData<DiscreteCollection> message = new ReadCoilsInputsResponse(Modbus.ReadCoils, 1, 2,
                 new DiscreteCollection(true));
             byte[] expectedResult = {1, 2, 1};
-            Assert.AreEqual(expectedResult, message.ProtocolDataUnit);
+            Assert.Equal(expectedResult, message.ProtocolDataUnit);
         }
 
-        [Test]
+        [Fact]
         public void DataReadCoilsResponse()
         {
             DiscreteCollection col = new DiscreteCollection(false, true, false, true, false, true, false, false, false,
                 false);
             AbstractModbusMessageWithData<DiscreteCollection> message = new ReadCoilsInputsResponse(Modbus.ReadCoils, 11, 1, col);
-            Assert.AreEqual(col.Count, message.Data.Count);
-            Assert.AreEqual(col.NetworkBytes, message.Data.NetworkBytes);
+            Assert.Equal(col.Count, message.Data.Count);
+            Assert.Equal(col.NetworkBytes, message.Data.NetworkBytes);
         }
     }
 }

--- a/NModbus4.UnitTests/Message/ReadCoilsInputsRequestFixture.cs
+++ b/NModbus4.UnitTests/Message/ReadCoilsInputsRequestFixture.cs
@@ -1,61 +1,59 @@
 using System;
 using Modbus.Message;
+using Xunit;
 
 namespace Modbus.UnitTests.Message
 {
-    using NUnit.Framework;
-
-    [TestFixture]
     public class ReadCoilsInputsRequestFixture
     {
-        [Test]
+        [Fact]
         public void CreateReadCoilsRequest()
         {
             ReadCoilsInputsRequest request = new ReadCoilsInputsRequest(Modbus.ReadCoils, 5, 1, 10);
-            Assert.AreEqual(Modbus.ReadCoils, request.FunctionCode);
-            Assert.AreEqual(5, request.SlaveAddress);
-            Assert.AreEqual(1, request.StartAddress);
-            Assert.AreEqual(10, request.NumberOfPoints);
+            Assert.Equal(Modbus.ReadCoils, request.FunctionCode);
+            Assert.Equal(5, request.SlaveAddress);
+            Assert.Equal(1, request.StartAddress);
+            Assert.Equal(10, request.NumberOfPoints);
         }
 
-        [Test]
+        [Fact]
         public void CreateReadInputsRequest()
         {
             ReadCoilsInputsRequest request = new ReadCoilsInputsRequest(Modbus.ReadInputs, 5, 1, 10);
-            Assert.AreEqual(Modbus.ReadInputs, request.FunctionCode);
-            Assert.AreEqual(5, request.SlaveAddress);
-            Assert.AreEqual(1, request.StartAddress);
-            Assert.AreEqual(10, request.NumberOfPoints);
+            Assert.Equal(Modbus.ReadInputs, request.FunctionCode);
+            Assert.Equal(5, request.SlaveAddress);
+            Assert.Equal(1, request.StartAddress);
+            Assert.Equal(10, request.NumberOfPoints);
         }
 
-        [Test, ExpectedException(typeof (ArgumentOutOfRangeException))]
+        [Fact]
         public void CreateReadCoilsInputsRequestTooMuchData()
         {
-            new ReadCoilsInputsRequest(Modbus.ReadCoils, 1, 2, Modbus.MaximumDiscreteRequestResponseSize + 1);
+            Assert.Throws<ArgumentOutOfRangeException>(() => new ReadCoilsInputsRequest(Modbus.ReadCoils, 1, 2, Modbus.MaximumDiscreteRequestResponseSize + 1));
         }
 
-        [Test]
+        [Fact]
         public void CreateReadCoilsInputsRequestMaxSize()
         {
             ReadCoilsInputsRequest response = new ReadCoilsInputsRequest(Modbus.ReadCoils, 1, 2,
                 Modbus.MaximumDiscreteRequestResponseSize);
-            Assert.AreEqual(Modbus.MaximumDiscreteRequestResponseSize, response.NumberOfPoints);
+            Assert.Equal(Modbus.MaximumDiscreteRequestResponseSize, response.NumberOfPoints);
         }
 
-        [Test]
+        [Fact]
         public void ToString_ReadCoilsRequest()
         {
             ReadCoilsInputsRequest request = new ReadCoilsInputsRequest(Modbus.ReadCoils, 5, 1, 10);
 
-            Assert.AreEqual("Read 10 coils starting at address 1.", request.ToString());
+            Assert.Equal("Read 10 coils starting at address 1.", request.ToString());
         }
 
-        [Test]
+        [Fact]
         public void ToString_ReadInputsRequest()
         {
             ReadCoilsInputsRequest request = new ReadCoilsInputsRequest(Modbus.ReadInputs, 5, 1, 10);
 
-            Assert.AreEqual("Read 10 inputs starting at address 1.", request.ToString());
+            Assert.Equal("Read 10 inputs starting at address 1.", request.ToString());
         }
     }
 }

--- a/NModbus4.UnitTests/Message/ReadCoilsInputsResponseFixture.cs
+++ b/NModbus4.UnitTests/Message/ReadCoilsInputsResponseFixture.cs
@@ -1,55 +1,53 @@
 using Modbus.Data;
 using Modbus.Message;
+using Xunit;
 
 namespace Modbus.UnitTests.Message
 {
-    using NUnit.Framework;
-
-    [TestFixture]
     public class ReadCoilsResponseFixture
     {
-        [Test]
+        [Fact]
         public void CreateReadCoilsResponse()
         {
             ReadCoilsInputsResponse response = new ReadCoilsInputsResponse(Modbus.ReadCoils, 5, 2,
                 new DiscreteCollection(true, true, true, true, true, true, false, false, true, true, false));
-            Assert.AreEqual(Modbus.ReadCoils, response.FunctionCode);
-            Assert.AreEqual(5, response.SlaveAddress);
-            Assert.AreEqual(2, response.ByteCount);
+            Assert.Equal(Modbus.ReadCoils, response.FunctionCode);
+            Assert.Equal(5, response.SlaveAddress);
+            Assert.Equal(2, response.ByteCount);
             DiscreteCollection col = new DiscreteCollection(true, true, true, true, true, true, false, false, true, true,
                 false);
-            Assert.AreEqual(col.NetworkBytes, response.Data.NetworkBytes);
+            Assert.Equal(col.NetworkBytes, response.Data.NetworkBytes);
         }
 
-        [Test]
+        [Fact]
         public void CreateReadInputsResponse()
         {
             ReadCoilsInputsResponse response = new ReadCoilsInputsResponse(Modbus.ReadInputs, 5, 2,
                 new DiscreteCollection(true, true, true, true, true, true, false, false, true, true, false));
-            Assert.AreEqual(Modbus.ReadInputs, response.FunctionCode);
-            Assert.AreEqual(5, response.SlaveAddress);
-            Assert.AreEqual(2, response.ByteCount);
+            Assert.Equal(Modbus.ReadInputs, response.FunctionCode);
+            Assert.Equal(5, response.SlaveAddress);
+            Assert.Equal(2, response.ByteCount);
             DiscreteCollection col = new DiscreteCollection(true, true, true, true, true, true, false, false, true, true,
                 false);
-            Assert.AreEqual(col.NetworkBytes, response.Data.NetworkBytes);
+            Assert.Equal(col.NetworkBytes, response.Data.NetworkBytes);
         }
 
-        [Test]
+        [Fact]
         public void ToString_Coils()
         {
             ReadCoilsInputsResponse response = new ReadCoilsInputsResponse(Modbus.ReadCoils, 5, 2,
                 new DiscreteCollection(true, true, true, true, true, true, false, false, true, true, false));
 
-            Assert.AreEqual("Read 11 coils - {1, 1, 1, 1, 1, 1, 0, 0, 1, 1, 0}.", response.ToString());
+            Assert.Equal("Read 11 coils - {1, 1, 1, 1, 1, 1, 0, 0, 1, 1, 0}.", response.ToString());
         }
 
-        [Test]
+        [Fact]
         public void ToString_Inputs()
         {
             ReadCoilsInputsResponse response = new ReadCoilsInputsResponse(Modbus.ReadInputs, 5, 2,
                 new DiscreteCollection(true, true, true, true, true, true, false, false, true, true, false));
 
-            Assert.AreEqual("Read 11 inputs - {1, 1, 1, 1, 1, 1, 0, 0, 1, 1, 0}.", response.ToString());
+            Assert.Equal("Read 11 inputs - {1, 1, 1, 1, 1, 1, 0, 0, 1, 1, 0}.", response.ToString());
         }
     }
 }

--- a/NModbus4.UnitTests/Message/ReadHoldingInputRegistersRequestFixture.cs
+++ b/NModbus4.UnitTests/Message/ReadHoldingInputRegistersRequestFixture.cs
@@ -1,66 +1,64 @@
 using System;
 using Modbus.Message;
+using Xunit;
 
 namespace Modbus.UnitTests.Message
 {
-    using NUnit.Framework;
-
-    [TestFixture]
     public class ReadHoldingInputRegistersRequestFixture
     {
-        [Test]
+        [Fact]
         public void CreateReadHoldingRegistersRequest()
         {
             ReadHoldingInputRegistersRequest request = new ReadHoldingInputRegistersRequest(
                 Modbus.ReadHoldingRegisters, 5, 1, 10);
-            Assert.AreEqual(Modbus.ReadHoldingRegisters, request.FunctionCode);
-            Assert.AreEqual(5, request.SlaveAddress);
-            Assert.AreEqual(1, request.StartAddress);
-            Assert.AreEqual(10, request.NumberOfPoints);
+            Assert.Equal(Modbus.ReadHoldingRegisters, request.FunctionCode);
+            Assert.Equal(5, request.SlaveAddress);
+            Assert.Equal(1, request.StartAddress);
+            Assert.Equal(10, request.NumberOfPoints);
         }
 
-        [Test]
+        [Fact]
         public void CreateReadInputRegistersRequest()
         {
             ReadHoldingInputRegistersRequest request = new ReadHoldingInputRegistersRequest(Modbus.ReadInputRegisters, 5,
                 1, 10);
-            Assert.AreEqual(Modbus.ReadInputRegisters, request.FunctionCode);
-            Assert.AreEqual(5, request.SlaveAddress);
-            Assert.AreEqual(1, request.StartAddress);
-            Assert.AreEqual(10, request.NumberOfPoints);
+            Assert.Equal(Modbus.ReadInputRegisters, request.FunctionCode);
+            Assert.Equal(5, request.SlaveAddress);
+            Assert.Equal(1, request.StartAddress);
+            Assert.Equal(10, request.NumberOfPoints);
         }
 
-        [Test, ExpectedException(typeof (ArgumentOutOfRangeException))]
+        [Fact]
         public void CreateReadHoldingInputRegistersRequestTooMuchData()
         {
-            new ReadHoldingInputRegistersRequest(Modbus.ReadHoldingRegisters, 1, 2,
-                Modbus.MaximumRegisterRequestResponseSize + 1);
+            Assert.Throws<ArgumentOutOfRangeException>(() => new ReadHoldingInputRegistersRequest(Modbus.ReadHoldingRegisters, 1, 2,
+                Modbus.MaximumRegisterRequestResponseSize + 1));
         }
 
-        [Test]
+        [Fact]
         public void CreateReadHoldingInputRegistersRequestMaxSize()
         {
             ReadHoldingInputRegistersRequest response = new ReadHoldingInputRegistersRequest(
                 Modbus.ReadHoldingRegisters, 1, 2, Modbus.MaximumRegisterRequestResponseSize);
-            Assert.AreEqual(Modbus.MaximumRegisterRequestResponseSize, response.NumberOfPoints);
+            Assert.Equal(Modbus.MaximumRegisterRequestResponseSize, response.NumberOfPoints);
         }
 
-        [Test]
+        [Fact]
         public void ToString_ReadHoldingRegistersRequest()
         {
             ReadHoldingInputRegistersRequest request = new ReadHoldingInputRegistersRequest(
                 Modbus.ReadHoldingRegisters, 5, 1, 10);
 
-            Assert.AreEqual("Read 10 holding registers starting at address 1.", request.ToString());
+            Assert.Equal("Read 10 holding registers starting at address 1.", request.ToString());
         }
 
-        [Test]
+        [Fact]
         public void ToString_ReadInputRegistersRequest()
         {
             ReadHoldingInputRegistersRequest request = new ReadHoldingInputRegistersRequest(Modbus.ReadInputRegisters, 5,
                 1, 10);
 
-            Assert.AreEqual("Read 10 input registers starting at address 1.", request.ToString());
+            Assert.Equal("Read 10 input registers starting at address 1.", request.ToString());
         }
     }
 }

--- a/NModbus4.UnitTests/Message/ReadHoldingInputRegistersResponseFixture.cs
+++ b/NModbus4.UnitTests/Message/ReadHoldingInputRegistersResponseFixture.cs
@@ -1,58 +1,56 @@
+using System;
 using Modbus.Data;
 using Modbus.Message;
+using Xunit;
 
 namespace Modbus.UnitTests.Message
 {
-    using System;
-    using NUnit.Framework;
-
-    [TestFixture]
     public class ReadHoldingInputRegistersResponseFixture
     {
-        [Test, ExpectedException(typeof (ArgumentNullException))]
+        [Fact]
         public void ReadHoldingInputRegistersResponse_NullData()
         {
-            new ReadHoldingInputRegistersResponse(0, 0, null);
+            Assert.Throws<ArgumentNullException>(() => new ReadHoldingInputRegistersResponse(0, 0, null));
         }
 
-        [Test]
+        [Fact]
         public void ReadHoldingRegistersResponse()
         {
             ReadHoldingInputRegistersResponse response =
                 new ReadHoldingInputRegistersResponse(Modbus.ReadHoldingRegisters, 5, new RegisterCollection(1, 2));
-            Assert.AreEqual(Modbus.ReadHoldingRegisters, response.FunctionCode);
-            Assert.AreEqual(5, response.SlaveAddress);
-            Assert.AreEqual(4, response.ByteCount);
+            Assert.Equal(Modbus.ReadHoldingRegisters, response.FunctionCode);
+            Assert.Equal(5, response.SlaveAddress);
+            Assert.Equal(4, response.ByteCount);
             RegisterCollection col = new RegisterCollection(1, 2);
-            Assert.AreEqual(col.NetworkBytes, response.Data.NetworkBytes);
+            Assert.Equal(col.NetworkBytes, response.Data.NetworkBytes);
         }
 
-        [Test]
+        [Fact]
         public void ToString_ReadHoldingRegistersResponse()
         {
             ReadHoldingInputRegistersResponse response =
                 new ReadHoldingInputRegistersResponse(Modbus.ReadHoldingRegisters, 1, new RegisterCollection(1));
-            Assert.AreEqual("Read 1 holding registers.", response.ToString());
+            Assert.Equal("Read 1 holding registers.", response.ToString());
         }
 
-        [Test]
+        [Fact]
         public void ReadInputRegistersResponse()
         {
             ReadHoldingInputRegistersResponse response = new ReadHoldingInputRegistersResponse(
                 Modbus.ReadInputRegisters, 5, new RegisterCollection(1, 2));
-            Assert.AreEqual(Modbus.ReadInputRegisters, response.FunctionCode);
-            Assert.AreEqual(5, response.SlaveAddress);
-            Assert.AreEqual(4, response.ByteCount);
+            Assert.Equal(Modbus.ReadInputRegisters, response.FunctionCode);
+            Assert.Equal(5, response.SlaveAddress);
+            Assert.Equal(4, response.ByteCount);
             RegisterCollection col = new RegisterCollection(1, 2);
-            Assert.AreEqual(col.NetworkBytes, response.Data.NetworkBytes);
+            Assert.Equal(col.NetworkBytes, response.Data.NetworkBytes);
         }
 
-        [Test]
+        [Fact]
         public void ToString_ReadInputRegistersResponse()
         {
             ReadHoldingInputRegistersResponse response = new ReadHoldingInputRegistersResponse(
                 Modbus.ReadInputRegisters, 1, new RegisterCollection(1));
-            Assert.AreEqual("Read 1 input registers.", response.ToString());
+            Assert.Equal("Read 1 input registers.", response.ToString());
         }
     }
 }

--- a/NModbus4.UnitTests/Message/ReadWriteMultipleRegistersRequestFixture.cs
+++ b/NModbus4.UnitTests/Message/ReadWriteMultipleRegistersRequestFixture.cs
@@ -1,36 +1,34 @@
 using Modbus.Data;
 using Modbus.Message;
+using Xunit;
 
 namespace Modbus.UnitTests.Message
 {
-    using NUnit.Framework;
-
-    [TestFixture]
     public class ReadWriteMultipleRegistersRequestFixture
     {
-        [Test]
+        [Fact]
         public void ReadWriteMultipleRegistersRequest()
         {
             RegisterCollection writeCollection = new RegisterCollection(255, 255, 255);
             ReadWriteMultipleRegistersRequest request = new ReadWriteMultipleRegistersRequest(5, 3, 6, 14,
                 writeCollection);
-            Assert.AreEqual(Modbus.ReadWriteMultipleRegisters, request.FunctionCode);
-            Assert.AreEqual(5, request.SlaveAddress);
+            Assert.Equal(Modbus.ReadWriteMultipleRegisters, request.FunctionCode);
+            Assert.Equal(5, request.SlaveAddress);
 
             // test read
-            Assert.IsNotNull(request.ReadRequest);
-            Assert.AreEqual(request.SlaveAddress, request.ReadRequest.SlaveAddress);
-            Assert.AreEqual(3, request.ReadRequest.StartAddress);
-            Assert.AreEqual(6, request.ReadRequest.NumberOfPoints);
+            Assert.NotNull(request.ReadRequest);
+            Assert.Equal(request.SlaveAddress, request.ReadRequest.SlaveAddress);
+            Assert.Equal(3, request.ReadRequest.StartAddress);
+            Assert.Equal(6, request.ReadRequest.NumberOfPoints);
 
             // test write
-            Assert.IsNotNull(request.WriteRequest);
-            Assert.AreEqual(request.SlaveAddress, request.WriteRequest.SlaveAddress);
-            Assert.AreEqual(14, request.WriteRequest.StartAddress);
-            Assert.AreEqual(writeCollection.NetworkBytes, request.WriteRequest.Data.NetworkBytes);
+            Assert.NotNull(request.WriteRequest);
+            Assert.Equal(request.SlaveAddress, request.WriteRequest.SlaveAddress);
+            Assert.Equal(14, request.WriteRequest.StartAddress);
+            Assert.Equal(writeCollection.NetworkBytes, request.WriteRequest.Data.NetworkBytes);
         }
 
-        [Test]
+        [Fact]
         public void ProtocolDataUnit()
         {
             RegisterCollection writeCollection = new RegisterCollection(255, 255, 255);
@@ -40,17 +38,17 @@ namespace Modbus.UnitTests.Message
             {
                 0x17, 0x00, 0x03, 0x00, 0x06, 0x00, 0x0e, 0x00, 0x03, 0x06, 0x00, 0xff, 0x00, 0xff, 0x00, 0xff
             };
-            Assert.AreEqual(pdu, request.ProtocolDataUnit);
+            Assert.Equal(pdu, request.ProtocolDataUnit);
         }
 
-        [Test]
+        [Fact]
         public void ToString_ReadWriteMultipleRegistersRequest()
         {
             RegisterCollection writeCollection = new RegisterCollection(255, 255, 255);
             ReadWriteMultipleRegistersRequest request = new ReadWriteMultipleRegistersRequest(5, 3, 6, 14,
                 writeCollection);
 
-            Assert.AreEqual(
+            Assert.Equal(
                 "Write 3 holding registers starting at address 14, and read 6 registers starting at address 3.",
                 request.ToString());
         }

--- a/NModbus4.UnitTests/Message/ReturnQueryDataRequestResponseFixture.cs
+++ b/NModbus4.UnitTests/Message/ReturnQueryDataRequestResponseFixture.cs
@@ -1,32 +1,30 @@
 using Modbus.Data;
 using Modbus.Message;
+using Xunit;
 
 namespace Modbus.UnitTests.Message
 {
-    using NUnit.Framework;
-
-    [TestFixture]
     public class ReturnQueryDataRequestResponseFixture
     {
-        [Test]
+        [Fact]
         public void ReturnQueryDataRequestResponse()
         {
             RegisterCollection data = new RegisterCollection(1, 2, 3, 4);
             DiagnosticsRequestResponse request = new DiagnosticsRequestResponse(Modbus.DiagnosticsReturnQueryData, 5,
                 data);
-            Assert.AreEqual(Modbus.Diagnostics, request.FunctionCode);
-            Assert.AreEqual(Modbus.DiagnosticsReturnQueryData, request.SubFunctionCode);
-            Assert.AreEqual(5, request.SlaveAddress);
-            Assert.AreEqual(data.NetworkBytes, request.Data.NetworkBytes);
+            Assert.Equal(Modbus.Diagnostics, request.FunctionCode);
+            Assert.Equal(Modbus.DiagnosticsReturnQueryData, request.SubFunctionCode);
+            Assert.Equal(5, request.SlaveAddress);
+            Assert.Equal(data.NetworkBytes, request.Data.NetworkBytes);
         }
 
-        [Test]
+        [Fact]
         public void ProtocolDataUnit()
         {
             RegisterCollection data = new RegisterCollection(1, 2, 3, 4);
             DiagnosticsRequestResponse request = new DiagnosticsRequestResponse(Modbus.DiagnosticsReturnQueryData, 5,
                 data);
-            Assert.AreEqual(new byte[] {8, 0, 0, 0, 1, 0, 2, 0, 3, 0, 4}, request.ProtocolDataUnit);
+            Assert.Equal(new byte[] {8, 0, 0, 0, 1, 0, 2, 0, 3, 0, 4}, request.ProtocolDataUnit);
         }
     }
 }

--- a/NModbus4.UnitTests/Message/SlaveExceptionResponseFixture.cs
+++ b/NModbus4.UnitTests/Message/SlaveExceptionResponseFixture.cs
@@ -1,28 +1,26 @@
 using Modbus.Message;
+using Xunit;
 
 namespace Modbus.UnitTests.Message
 {
-    using NUnit.Framework;
-
-    [TestFixture]
     public class SlaveExceptionResponseFixture
     {
-        [Test]
+        [Fact]
         public void CreateSlaveExceptionResponse()
         {
             SlaveExceptionResponse response = new SlaveExceptionResponse(11, Modbus.ReadCoils + Modbus.ExceptionOffset,
                 2);
-            Assert.AreEqual(11, response.SlaveAddress);
-            Assert.AreEqual(Modbus.ReadCoils + Modbus.ExceptionOffset, response.FunctionCode);
-            Assert.AreEqual(2, response.SlaveExceptionCode);
+            Assert.Equal(11, response.SlaveAddress);
+            Assert.Equal(Modbus.ReadCoils + Modbus.ExceptionOffset, response.FunctionCode);
+            Assert.Equal(2, response.SlaveExceptionCode);
         }
 
-        [Test]
+        [Fact]
         public void SlaveExceptionResponsePDU()
         {
             SlaveExceptionResponse response = new SlaveExceptionResponse(11, Modbus.ReadCoils + Modbus.ExceptionOffset,
                 2);
-            Assert.AreEqual(new byte[] {response.FunctionCode, response.SlaveExceptionCode}, response.ProtocolDataUnit);
+            Assert.Equal(new byte[] {response.FunctionCode, response.SlaveExceptionCode}, response.ProtocolDataUnit);
         }
     }
 }

--- a/NModbus4.UnitTests/Message/WriteMultipleCoilsRequestFixture.cs
+++ b/NModbus4.UnitTests/Message/WriteMultipleCoilsRequestFixture.cs
@@ -1,51 +1,50 @@
 using System;
 using Modbus.Data;
 using Modbus.Message;
+using Xunit;
 
 namespace Modbus.UnitTests.Message
 {
-    using NUnit.Framework;
-
-    [TestFixture]
     public class WriteMultipleCoilsRequestFixture
     {
-        [Test]
+        [Fact]
         public void CreateWriteMultipleCoilsRequest()
         {
             DiscreteCollection col = new DiscreteCollection(true, false, true, false, true, true, true, false, false);
             WriteMultipleCoilsRequest request = new WriteMultipleCoilsRequest(34, 45, col);
-            Assert.AreEqual(Modbus.WriteMultipleCoils, request.FunctionCode);
-            Assert.AreEqual(34, request.SlaveAddress);
-            Assert.AreEqual(45, request.StartAddress);
-            Assert.AreEqual(9, request.NumberOfPoints);
-            Assert.AreEqual(2, request.ByteCount);
-            Assert.AreEqual(col.NetworkBytes, request.Data.NetworkBytes);
+            Assert.Equal(Modbus.WriteMultipleCoils, request.FunctionCode);
+            Assert.Equal(34, request.SlaveAddress);
+            Assert.Equal(45, request.StartAddress);
+            Assert.Equal(9, request.NumberOfPoints);
+            Assert.Equal(2, request.ByteCount);
+            Assert.Equal(col.NetworkBytes, request.Data.NetworkBytes);
         }
 
-        [Test, ExpectedException(typeof (ArgumentOutOfRangeException))]
+        [Fact]
         public void CreateWriteMultipleCoilsRequestTooMuchData()
         {
-            new WriteMultipleCoilsRequest(1, 2,
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                new WriteMultipleCoilsRequest(1, 2,
                 MessageUtility.CreateDefaultCollection<DiscreteCollection, bool>(true,
-                    Modbus.MaximumDiscreteRequestResponseSize + 1));
+                    Modbus.MaximumDiscreteRequestResponseSize + 1)));
         }
 
-        [Test]
+        [Fact]
         public void CreateWriteMultipleCoilsRequestMaxSize()
         {
             WriteMultipleCoilsRequest request = new WriteMultipleCoilsRequest(1, 2,
                 MessageUtility.CreateDefaultCollection<DiscreteCollection, bool>(true,
                     Modbus.MaximumDiscreteRequestResponseSize));
-            Assert.AreEqual(Modbus.MaximumDiscreteRequestResponseSize, request.Data.Count);
+            Assert.Equal(Modbus.MaximumDiscreteRequestResponseSize, request.Data.Count);
         }
 
-        [Test]
+        [Fact]
         public void ToString_WriteMultipleCoilsRequest()
         {
             DiscreteCollection col = new DiscreteCollection(true, false, true, false, true, true, true, false, false);
             WriteMultipleCoilsRequest request = new WriteMultipleCoilsRequest(34, 45, col);
 
-            Assert.AreEqual("Write 9 coils starting at address 45.", request.ToString());
+            Assert.Equal("Write 9 coils starting at address 45.", request.ToString());
         }
     }
 }

--- a/NModbus4.UnitTests/Message/WriteMultipleCoilsResponseFixture.cs
+++ b/NModbus4.UnitTests/Message/WriteMultipleCoilsResponseFixture.cs
@@ -1,43 +1,41 @@
 using System;
 using Modbus.Message;
+using Xunit;
 
 namespace Modbus.UnitTests.Message
 {
-    using NUnit.Framework;
-
-    [TestFixture]
     public class WriteMultipleCoilsResponseFixture
     {
-        [Test]
+        [Fact]
         public void CreateWriteMultipleCoilsResponse()
         {
             WriteMultipleCoilsResponse response = new WriteMultipleCoilsResponse(17, 19, 45);
-            Assert.AreEqual(Modbus.WriteMultipleCoils, response.FunctionCode);
-            Assert.AreEqual(17, response.SlaveAddress);
-            Assert.AreEqual(19, response.StartAddress);
-            Assert.AreEqual(45, response.NumberOfPoints);
+            Assert.Equal(Modbus.WriteMultipleCoils, response.FunctionCode);
+            Assert.Equal(17, response.SlaveAddress);
+            Assert.Equal(19, response.StartAddress);
+            Assert.Equal(45, response.NumberOfPoints);
         }
 
-        [Test, ExpectedException(typeof (ArgumentOutOfRangeException))]
+        [Fact]
         public void CreateWriteMultipleCoilsResponseTooMuchData()
         {
-            new WriteMultipleCoilsResponse(1, 2, Modbus.MaximumDiscreteRequestResponseSize + 1);
+            Assert.Throws<ArgumentOutOfRangeException>(() => new WriteMultipleCoilsResponse(1, 2, Modbus.MaximumDiscreteRequestResponseSize + 1));
         }
 
-        [Test]
+        [Fact]
         public void CreateWriteMultipleCoilsResponseMaxSize()
         {
             WriteMultipleCoilsResponse response = new WriteMultipleCoilsResponse(1, 2,
                 Modbus.MaximumDiscreteRequestResponseSize);
-            Assert.AreEqual(Modbus.MaximumDiscreteRequestResponseSize, response.NumberOfPoints);
+            Assert.Equal(Modbus.MaximumDiscreteRequestResponseSize, response.NumberOfPoints);
         }
 
-        [Test]
+        [Fact]
         public void ToString_Test()
         {
             var response = new WriteMultipleCoilsResponse(1, 2, 3);
 
-            Assert.AreEqual("Wrote 3 coils starting at address 2.", response.ToString());
+            Assert.Equal("Wrote 3 coils starting at address 2.", response.ToString());
         }
     }
 }

--- a/NModbus4.UnitTests/Message/WriteMultipleRegistersRequestFixture.cs
+++ b/NModbus4.UnitTests/Message/WriteMultipleRegistersRequestFixture.cs
@@ -1,50 +1,49 @@
 using System;
 using Modbus.Data;
 using Modbus.Message;
+using Xunit;
 
 namespace Modbus.UnitTests.Message
 {
-    using NUnit.Framework;
-
-    [TestFixture]
     public class WriteMultipleRegistersRequestFixture
     {
-        [Test]
+        [Fact]
         public void CreateWriteMultipleRegistersRequestFixture()
         {
             RegisterCollection col = new RegisterCollection(10, 20, 30, 40, 50);
             WriteMultipleRegistersRequest request = new WriteMultipleRegistersRequest(11, 34, col);
-            Assert.AreEqual(Modbus.WriteMultipleRegisters, request.FunctionCode);
-            Assert.AreEqual(11, request.SlaveAddress);
-            Assert.AreEqual(34, request.StartAddress);
-            Assert.AreEqual(10, request.ByteCount);
-            Assert.AreEqual(col.NetworkBytes, request.Data.NetworkBytes);
+            Assert.Equal(Modbus.WriteMultipleRegisters, request.FunctionCode);
+            Assert.Equal(11, request.SlaveAddress);
+            Assert.Equal(34, request.StartAddress);
+            Assert.Equal(10, request.ByteCount);
+            Assert.Equal(col.NetworkBytes, request.Data.NetworkBytes);
         }
 
-        [Test, ExpectedException(typeof (ArgumentOutOfRangeException))]
+        [Fact]
         public void CreateWriteMultipleRegistersRequestTooMuchData()
         {
-            new WriteMultipleRegistersRequest(1, 2,
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                new WriteMultipleRegistersRequest(1, 2,
                 MessageUtility.CreateDefaultCollection<RegisterCollection, ushort>(3,
-                    Modbus.MaximumRegisterRequestResponseSize + 1));
+                    Modbus.MaximumRegisterRequestResponseSize + 1)));
         }
 
-        [Test]
+        [Fact]
         public void CreateWriteMultipleRegistersRequestMaxSize()
         {
             WriteMultipleRegistersRequest request = new WriteMultipleRegistersRequest(1, 2,
                 MessageUtility.CreateDefaultCollection<RegisterCollection, ushort>(3,
                     Modbus.MaximumRegisterRequestResponseSize));
-            Assert.AreEqual(Modbus.MaximumRegisterRequestResponseSize, request.NumberOfPoints);
+            Assert.Equal(Modbus.MaximumRegisterRequestResponseSize, request.NumberOfPoints);
         }
 
-        [Test]
+        [Fact]
         public void ToString_WriteMultipleRegistersRequest()
         {
             RegisterCollection col = new RegisterCollection(10, 20, 30, 40, 50);
             WriteMultipleRegistersRequest request = new WriteMultipleRegistersRequest(11, 34, col);
 
-            Assert.AreEqual("Write 5 holding registers starting at address 34.", request.ToString());
+            Assert.Equal("Write 5 holding registers starting at address 34.", request.ToString());
         }
     }
 }

--- a/NModbus4.UnitTests/Message/WriteMultipleRegistersResponseFixture.cs
+++ b/NModbus4.UnitTests/Message/WriteMultipleRegistersResponseFixture.cs
@@ -1,43 +1,41 @@
 using System;
 using Modbus.Message;
+using Xunit;
 
 namespace Modbus.UnitTests.Message
 {
-    using NUnit.Framework;
-
-    [TestFixture]
     public class WriteMultipleRegistersResponseFixture
     {
-        [Test]
+        [Fact]
         public void CreateWriteMultipleRegistersResponse()
         {
             WriteMultipleRegistersResponse response = new WriteMultipleRegistersResponse(12, 39, 2);
-            Assert.AreEqual(Modbus.WriteMultipleRegisters, response.FunctionCode);
-            Assert.AreEqual(12, response.SlaveAddress);
-            Assert.AreEqual(39, response.StartAddress);
-            Assert.AreEqual(2, response.NumberOfPoints);
+            Assert.Equal(Modbus.WriteMultipleRegisters, response.FunctionCode);
+            Assert.Equal(12, response.SlaveAddress);
+            Assert.Equal(39, response.StartAddress);
+            Assert.Equal(2, response.NumberOfPoints);
         }
 
-        [Test, ExpectedException(typeof (ArgumentOutOfRangeException))]
+        [Fact]
         public void CreateWriteMultipleRegistersResponseTooMuchData()
         {
-            new WriteMultipleRegistersResponse(1, 2, Modbus.MaximumRegisterRequestResponseSize + 1);
+            Assert.Throws<ArgumentOutOfRangeException>(() => new WriteMultipleRegistersResponse(1, 2, Modbus.MaximumRegisterRequestResponseSize + 1));
         }
 
-        [Test]
+        [Fact]
         public void CreateWriteMultipleRegistersResponseMaxSize()
         {
             WriteMultipleRegistersResponse response = new WriteMultipleRegistersResponse(1, 2,
                 Modbus.MaximumRegisterRequestResponseSize);
-            Assert.AreEqual(Modbus.MaximumRegisterRequestResponseSize, response.NumberOfPoints);
+            Assert.Equal(Modbus.MaximumRegisterRequestResponseSize, response.NumberOfPoints);
         }
 
-        [Test]
+        [Fact]
         public void ToString_Test()
         {
             var response = new WriteMultipleRegistersResponse(1, 2, 3);
 
-            Assert.AreEqual("Wrote 3 holding registers starting at address 2.", response.ToString());
+            Assert.Equal("Wrote 3 holding registers starting at address 2.", response.ToString());
         }
     }
 }

--- a/NModbus4.UnitTests/Message/WriteSingleCoilRequestResponseFixture.cs
+++ b/NModbus4.UnitTests/Message/WriteSingleCoilRequestResponseFixture.cs
@@ -1,36 +1,34 @@
 using Modbus.Message;
+using Xunit;
 
 namespace Modbus.UnitTests.Message
 {
-    using NUnit.Framework;
-
-    [TestFixture]
     public class WriteSingleCoilRequestResponseFixture
     {
-        [Test]
+        [Fact]
         public void NewWriteSingleCoilRequestResponse()
         {
             WriteSingleCoilRequestResponse request = new WriteSingleCoilRequestResponse(11, 5, true);
-            Assert.AreEqual(11, request.SlaveAddress);
-            Assert.AreEqual(5, request.StartAddress);
-            Assert.AreEqual(1, request.Data.Count);
-            Assert.AreEqual(Modbus.CoilOn, request.Data[0]);
+            Assert.Equal(11, request.SlaveAddress);
+            Assert.Equal(5, request.StartAddress);
+            Assert.Equal(1, request.Data.Count);
+            Assert.Equal(Modbus.CoilOn, request.Data[0]);
         }
 
-        [Test]
+        [Fact]
         public void ToString_True()
         {
             var request = new WriteSingleCoilRequestResponse(11, 5, true);
 
-            Assert.AreEqual("Write single coil 1 at address 5.", request.ToString());
+            Assert.Equal("Write single coil 1 at address 5.", request.ToString());
         }
 
-        [Test]
+        [Fact]
         public void ToString_False()
         {
             var request = new WriteSingleCoilRequestResponse(11, 5, false);
 
-            Assert.AreEqual("Write single coil 0 at address 5.", request.ToString());
+            Assert.Equal("Write single coil 0 at address 5.", request.ToString());
         }
     }
 }

--- a/NModbus4.UnitTests/Message/WriteSingleRegisterRequestResponseFixture.cs
+++ b/NModbus4.UnitTests/Message/WriteSingleRegisterRequestResponseFixture.cs
@@ -1,27 +1,25 @@
 using Modbus.Message;
+using Xunit;
 
 namespace Modbus.UnitTests.Message
 {
-    using NUnit.Framework;
-
-    [TestFixture]
     public class WriteSingleRegisterRequestResponseFixture
     {
-        [Test]
+        [Fact]
         public void NewWriteSingleRegisterRequestResponse()
         {
             WriteSingleRegisterRequestResponse message = new WriteSingleRegisterRequestResponse(12, 5, 1200);
-            Assert.AreEqual(12, message.SlaveAddress);
-            Assert.AreEqual(5, message.StartAddress);
-            Assert.AreEqual(1, message.Data.Count);
-            Assert.AreEqual(1200, message.Data[0]);
+            Assert.Equal(12, message.SlaveAddress);
+            Assert.Equal(5, message.StartAddress);
+            Assert.Equal(1, message.Data.Count);
+            Assert.Equal(1200, message.Data[0]);
         }
 
-        [Test]
+        [Fact]
         public void ToStringOverride()
         {
             WriteSingleRegisterRequestResponse message = new WriteSingleRegisterRequestResponse(12, 5, 1200);
-            Assert.AreEqual("Write single holding register 1200 at address 5.", message.ToString());
+            Assert.Equal("Write single holding register 1200 at address 5.", message.ToString());
         }
     }
 }

--- a/NModbus4.UnitTests/NModbus4.UnitTests.csproj
+++ b/NModbus4.UnitTests/NModbus4.UnitTests.csproj
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="12.0">
+  <Import Project="..\packages\xunit.runner.visualstudio.2.0.1\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.0.1\build\net20\xunit.runner.visualstudio.props')" />
+  <Import Project="..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props" Condition="Exists('..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -10,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Modbus.UnitTests</RootNamespace>
     <AssemblyName>Modbus.UnitTests</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
     <UpgradeBackupLocation>
@@ -34,6 +36,8 @@
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -44,6 +48,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <UseVSHostingProcess>true</UseVSHostingProcess>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -53,6 +58,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <UseVSHostingProcess>false</UseVSHostingProcess>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Test|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -61,6 +67,7 @@
     <DebugType>full</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'SignedRelease|AnyCPU' ">
     <OutputPath>bin\SignedRelease\</OutputPath>
@@ -72,12 +79,9 @@
     <CodeAnalysisModuleSuppressionsFile>GlobalSuppressions.cs</CodeAnalysisModuleSuppressionsFile>
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <ErrorReport>prompt</ErrorReport>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
-    </Reference>
     <Reference Include="Rhino.Mocks, Version=3.6.0.0, Culture=neutral, PublicKeyToken=0b3305902db7183f, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\RhinoMocks.3.6.1\lib\net\Rhino.Mocks.dll</HintPath>
@@ -88,6 +92,18 @@
     </Reference>
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.assert, Version=2.0.0.2929, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.assert.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.assert.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.core, Version=2.0.0.2929, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.core.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Data\DataStoreEventArgsFixture.cs" />
@@ -151,6 +167,9 @@
     <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
@@ -158,6 +177,8 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+    <Error Condition="!Exists('..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props'))" />
+    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.0.1\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.0.1\build\net20\xunit.runner.visualstudio.props'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/NModbus4.UnitTests/Properties/AssemblyInfo.cs
+++ b/NModbus4.UnitTests/Properties/AssemblyInfo.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using Xunit;
 
 [assembly: AssemblyTitle("Modbus.UnitTests")]
 [assembly: AssemblyProduct("NModbus")]
@@ -10,3 +11,5 @@ using System.Runtime.InteropServices;
 [assembly: Guid("244bb5c5-2aec-437a-b1c3-4b312ace54fc")]
 [assembly: AssemblyVersion("1.11.0.0")]
 [assembly: AssemblyFileVersion("1.11.0.0")]
+
+[assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly, DisableTestParallelization = true, MaxParallelThreads = 1)]

--- a/NModbus4.UnitTests/SlaveExceptionFixture.cs
+++ b/NModbus4.UnitTests/SlaveExceptionFixture.cs
@@ -1,102 +1,101 @@
 using System;
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
-using NUnit.Framework;
+using Xunit;
 using Modbus.Message;
 
 namespace Modbus.UnitTests
 {
-    [TestFixture]
     public class SlaveExceptionFixture
     {
-        [Test]
+        [Fact]
         public void CreateSlaveException_EmptyConstructor()
         {
             SlaveException se = new SlaveException();
-            Assert.AreEqual("Exception of type 'Modbus.SlaveException' was thrown.", se.Message);
+            Assert.Equal("Exception of type 'Modbus.SlaveException' was thrown.", se.Message);
         }
 
-        [Test]
+        [Fact]
         public void CreateSlaveException_Message()
         {
             SlaveException se = new SlaveException("Hello World");
-            Assert.AreEqual("Hello World", se.Message);
+            Assert.Equal("Hello World", se.Message);
         }
 
-        [Test]
+        [Fact]
         public void CreateSlaveException_MessageAndInnerException()
         {
             SlaveException se = new SlaveException("Foo", new IOException("Bar"));
-            Assert.AreEqual("Foo", se.Message);
-            Assert.IsNotNull(se.InnerException);
-            Assert.AreEqual("Bar", se.InnerException.Message);
+            Assert.Equal("Foo", se.Message);
+            Assert.NotNull(se.InnerException);
+            Assert.Equal("Bar", se.InnerException.Message);
         }
 
-        [Test]
+        [Fact]
         public void CreateSlaveException_SlaveExceptionResponse()
         {
             SlaveExceptionResponse response = new SlaveExceptionResponse(12, Modbus.ReadCoils, 1);
             SlaveException se = new SlaveException(response);
-            Assert.AreEqual(
+            Assert.Equal(
                 String.Format(
                     "Exception of type 'Modbus.SlaveException' was thrown.\r\nFunction Code: {0}\r\nException Code: {1} - {2}",
                     response.FunctionCode, response.SlaveExceptionCode, Resources.IllegalFunction), se.Message);
         }
 
-        [Test]
+        [Fact]
         public void CreateSlaveException_CustomMessageAndSlaveExceptionResponse()
         {
             SlaveExceptionResponse response = new SlaveExceptionResponse(12, Modbus.ReadCoils, 2);
             string customMessage = "custom message";
             SlaveException se = new SlaveException(customMessage, response);
-            Assert.AreEqual(String.Format("{0}\r\nFunction Code: {1}\r\nException Code: {2} - {3}",
+            Assert.Equal(String.Format("{0}\r\nFunction Code: {1}\r\nException Code: {2} - {3}",
                 customMessage, response.FunctionCode, response.SlaveExceptionCode, Resources.IllegalDataAddress),
                 se.Message);
         }
 
-        [Test]
+        [Fact]
         public void FunctionCode_SlaveExceptionInitialized()
         {
             SlaveException se = new SlaveException(new SlaveExceptionResponse(1, 2, 3));
-            Assert.AreEqual(2, se.FunctionCode);
+            Assert.Equal(2, se.FunctionCode);
         }
 
-        [Test]
+        [Fact]
         public void FunctionCode_SlaveExceptionNotInitialized()
         {
             SlaveException se = new SlaveException();
-            Assert.AreEqual(0, se.FunctionCode);
+            Assert.Equal(0, se.FunctionCode);
         }
 
-        [Test]
+        [Fact]
         public void SlaveException_SlaveExceptionInitialized()
         {
             SlaveException se = new SlaveException(new SlaveExceptionResponse(1, 2, 3));
-            Assert.AreEqual(3, se.SlaveExceptionCode);
+            Assert.Equal(3, se.SlaveExceptionCode);
         }
 
-        [Test]
+        [Fact]
         public void SlaveExceptionCode_SlaveExceptionNotInitialized()
         {
             SlaveException se = new SlaveException();
-            Assert.AreEqual(0, se.SlaveExceptionCode);
+            Assert.Equal(0, se.SlaveExceptionCode);
         }
 
-        [Test]
+        [Fact]
         public void SlaveAddress_SlaveExceptionInitialized()
         {
             SlaveException se = new SlaveException(new SlaveExceptionResponse(1, 2, 3));
-            Assert.AreEqual(1, se.SlaveAddress);
+            Assert.Equal(1, se.SlaveAddress);
         }
 
-        [Test]
+        [Fact]
         public void SlaveAddress_SlaveExceptionNotInitialized()
         {
             SlaveException se = new SlaveException();
-            Assert.AreEqual(0, se.SlaveAddress);
+            Assert.Equal(0, se.SlaveAddress);
         }
 
-        [Test]
+        [Fact]
         public void SlaveException_Serializable()
         {
             BinaryFormatter formatter = new BinaryFormatter();
@@ -108,10 +107,10 @@ namespace Modbus.UnitTests
                 stream.Position = 0;
 
                 SlaveException slaveException2 = formatter.Deserialize(stream) as SlaveException;
-                Assert.IsNotNull(slaveException2);
-                Assert.AreEqual(1, slaveException2.SlaveAddress);
-                Assert.AreEqual(2, slaveException2.FunctionCode);
-                Assert.AreEqual(3, slaveException2.SlaveExceptionCode);
+                Assert.NotNull(slaveException2);
+                Assert.Equal(1, slaveException2.SlaveAddress);
+                Assert.Equal(2, slaveException2.FunctionCode);
+                Assert.Equal(3, slaveException2.SlaveExceptionCode);
             }
         }
     }

--- a/NModbus4.UnitTests/Utility/CollectionUtilityFixture.cs
+++ b/NModbus4.UnitTests/Utility/CollectionUtilityFixture.cs
@@ -4,77 +4,75 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using Modbus.Data;
 using Modbus.UnitTests.Message;
+using Modbus.Unme.Common;
+using Xunit;
 
 namespace Modbus.UnitTests.Utility
 {
-    using Unme.Common;
-    using NUnit.Framework;
-
-    [TestFixture]
     public class CollectionUtilityFixture
     {
-        [Test]
+        [Fact]
         public void SliceMiddle()
         {
             byte[] test = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-            Assert.AreEqual(new byte[] {3, 4, 5, 6, 7}, test.Slice(2, 5).ToArray());
+            Assert.Equal(new byte[] {3, 4, 5, 6, 7}, test.Slice(2, 5).ToArray());
         }
 
-        [Test]
+        [Fact]
         public void SliceBeginning()
         {
             byte[] test = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-            Assert.AreEqual(new byte[] {1, 2}, test.Slice(0, 2).ToArray());
+            Assert.Equal(new byte[] {1, 2}, test.Slice(0, 2).ToArray());
         }
 
-        [Test]
+        [Fact]
         public void SliceEnd()
         {
             byte[] test = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-            Assert.AreEqual(new byte[] {9, 10}, test.Slice(8, 2).ToArray());
+            Assert.Equal(new byte[] {9, 10}, test.Slice(8, 2).ToArray());
         }
 
-        [Test]
+        [Fact]
         public void SliceCollection()
         {
             Collection<bool> col = new Collection<bool>(new bool[] {true, false, false, false, true, true});
-            Assert.AreEqual(new bool[] {false, false, true}, col.Slice(2, 3).ToArray());
+            Assert.Equal(new bool[] {false, false, true}, col.Slice(2, 3).ToArray());
         }
 
-        [Test]
+        [Fact]
         public void SliceReadOnlyCollection()
         {
             ReadOnlyCollection<bool> col =
                 new ReadOnlyCollection<bool>(new bool[] {true, false, false, false, true, true});
-            Assert.AreEqual(new bool[] {false, false, true}, col.Slice(2, 3).ToArray());
+            Assert.Equal(new bool[] {false, false, true}, col.Slice(2, 3).ToArray());
         }
 
-        [Test, ExpectedException(typeof (ArgumentNullException))]
+        [Fact]
         public void SliceNullICollection()
         {
             ICollection<bool> col = null;
-            col.Slice(1, 1).ToArray();
+            Assert.Throws<ArgumentNullException>(() => col.Slice(1, 1).ToArray());
         }
 
-        [Test, ExpectedException(typeof (ArgumentNullException))]
+        [Fact]
         public void SliceNullArray()
         {
             bool[] array = null;
-            array.Slice(1, 1).ToArray();
+            Assert.Throws<ArgumentNullException>(() => array.Slice(1, 1).ToArray());
         }
 
-        [Test, ExpectedException(typeof (ArgumentOutOfRangeException))]
+        [Fact]
         public void CreateDefaultCollectionNegativeSize()
         {
-            MessageUtility.CreateDefaultCollection<RegisterCollection, ushort>(0, -1);
+            Assert.Throws<ArgumentOutOfRangeException>(() => MessageUtility.CreateDefaultCollection<RegisterCollection, ushort>(0, -1));
         }
 
-        [Test]
+        [Fact]
         public void CreateDefaultCollection()
         {
             RegisterCollection col = MessageUtility.CreateDefaultCollection<RegisterCollection, ushort>(3, 5);
-            Assert.AreEqual(5, col.Count);
-            Assert.AreEqual(new ushort[] {3, 3, 3, 3, 3}, col.ToArray());
+            Assert.Equal(5, col.Count);
+            Assert.Equal(new ushort[] {3, 3, 3, 3, 3}, col.ToArray());
         }
     }
 }

--- a/NModbus4.UnitTests/Utility/DiscriminatedUnionFixture.cs
+++ b/NModbus4.UnitTests/Utility/DiscriminatedUnionFixture.cs
@@ -1,56 +1,54 @@
 ﻿using System;
 using Modbus.Utility;
+using Xunit;
 
 namespace Modbus.UnitTests.Utility
 {
-    using NUnit.Framework;
-
-    [TestFixture]
     public class DiscriminatedUnionTestSuite
     {
-        [Test]
+        [Fact]
         public void DiscriminatedUnion_CreateA()
         {
             var du = DiscriminatedUnion<string, string>.CreateA("foo");
-            Assert.AreEqual(DiscriminatedUnionOption.A, du.Option);
-            Assert.AreEqual("foo", du.A);
+            Assert.Equal(DiscriminatedUnionOption.A, du.Option);
+            Assert.Equal("foo", du.A);
         }
 
-        [Test]
+        [Fact]
         public void DiscriminatedUnion_CreateB()
         {
             var du = DiscriminatedUnion<string, string>.CreateB("foo");
-            Assert.AreEqual(DiscriminatedUnionOption.B, du.Option);
-            Assert.AreEqual("foo", du.B);
+            Assert.Equal(DiscriminatedUnionOption.B, du.Option);
+            Assert.Equal("foo", du.B);
         }
 
-        [Test]
+        [Fact]
         public void DiscriminatedUnion_AllowNulls()
         {
             var du = DiscriminatedUnion<object, object>.CreateB(null);
-            Assert.AreEqual(DiscriminatedUnionOption.B, du.Option);
-            Assert.AreEqual(null, du.B);
+            Assert.Equal(DiscriminatedUnionOption.B, du.Option);
+            Assert.Equal(null, du.B);
         }
 
-        [Test, ExpectedException(typeof (InvalidOperationException))]
+        [Fact]
         public void AccessInvalidOption_A()
         {
             var du = DiscriminatedUnion<string, string>.CreateB("foo");
-            du.A.ToString();
+            Assert.Throws<InvalidOperationException>(() => du.A.ToString());
         }
 
-        [Test, ExpectedException(typeof (InvalidOperationException))]
+        [Fact]
         public void AccessInvalidOption_B()
         {
             var du = DiscriminatedUnion<string, string>.CreateA("foo");
-            du.B.ToString();
+            Assert.Throws<InvalidOperationException>(() => du.B.ToString());
         }
 
-        [Test]
+        [Fact]
         public void DiscriminatedUnion_ToString()
         {
             var du = DiscriminatedUnion<string, string>.CreateA("foo");
-            Assert.AreEqual(du.ToString(), "foo");
+            Assert.Equal(du.ToString(), "foo");
         }
     }
 }

--- a/NModbus4.UnitTests/Utility/ModbusUtilityFixture.cs
+++ b/NModbus4.UnitTests/Utility/ModbusUtilityFixture.cs
@@ -1,178 +1,169 @@
 using System;
 using Modbus.Message;
 using Modbus.Utility;
+using Xunit;
 
 namespace Modbus.UnitTests.Utility
 {
-    using NUnit.Framework;
-
-    [TestFixture]
     public class ModbusUtilityFixture
     {
-        [Test]
+        [Fact]
         public void GetAsciiBytesFromEmpty()
         {
-            Assert.AreEqual(new byte[] {}, ModbusUtility.GetAsciiBytes(new byte[] {}));
-            Assert.AreEqual(new byte[] {}, ModbusUtility.GetAsciiBytes(new ushort[] {}));
+            Assert.Equal(new byte[] {}, ModbusUtility.GetAsciiBytes(new byte[] {}));
+            Assert.Equal(new byte[] {}, ModbusUtility.GetAsciiBytes(new ushort[] {}));
         }
 
-        [Test]
+        [Fact]
         public void GetAsciiBytesFromBytes()
         {
             byte[] buf = {2, 5};
             byte[] expectedResult = {48, 50, 48, 53};
             byte[] result = ModbusUtility.GetAsciiBytes(buf);
-            Assert.AreEqual(expectedResult, result);
+            Assert.Equal(expectedResult, result);
         }
 
-        [Test]
+        [Fact]
         public void GetAsciiBytesFromUshorts()
         {
             ushort[] buf = {300, 400};
             byte[] expectedResult = {48, 49, 50, 67, 48, 49, 57, 48};
             byte[] result = ModbusUtility.GetAsciiBytes(buf);
-            Assert.AreEqual(expectedResult, result);
+            Assert.Equal(expectedResult, result);
         }
 
-        [Test]
+        [Fact]
         public void HexToBytes()
         {
-            Assert.AreEqual(new byte[] {255}, ModbusUtility.HexToBytes("FF"));
+            Assert.Equal(new byte[] {255}, ModbusUtility.HexToBytes("FF"));
         }
 
-        [Test]
+        [Fact]
         public void HexToBytes2()
         {
-            Assert.AreEqual(new byte[] {204, 255}, ModbusUtility.HexToBytes("CCFF"));
+            Assert.Equal(new byte[] {204, 255}, ModbusUtility.HexToBytes("CCFF"));
         }
 
-        [Test]
+        [Fact]
         public void HexToBytesEmpty()
         {
-            Assert.AreEqual(new byte[] {}, ModbusUtility.HexToBytes(""));
+            Assert.Equal(new byte[] {}, ModbusUtility.HexToBytes(""));
         }
 
-        [Test, ExpectedException(typeof (ArgumentNullException))]
+        [Fact]
         public void HexToBytesNull()
         {
-            ModbusUtility.HexToBytes(null);
-            Assert.Fail();
+            Assert.Throws<ArgumentNullException>(() => ModbusUtility.HexToBytes(null));
         }
 
-        [Test]
-        [ExpectedException(typeof (FormatException))]
+        [Fact]
         public void HexToBytesOdd()
         {
-            ModbusUtility.HexToBytes("CCF");
-            Assert.Fail();
+            Assert.Throws<FormatException>(() => ModbusUtility.HexToBytes("CCF"));
         }
 
-        [Test]
+        [Fact]
         public void CalculateCrc()
         {
             byte[] result = ModbusUtility.CalculateCrc(new byte[] {1, 1});
-            Assert.AreEqual(new byte[] {193, 224}, result);
+            Assert.Equal(new byte[] {193, 224}, result);
         }
 
-        [Test]
+        [Fact]
         public void CalculateCrc2()
         {
             byte[] result = ModbusUtility.CalculateCrc(new byte[] {2, 1, 5, 0});
-            Assert.AreEqual(new byte[] {83, 12}, result);
+            Assert.Equal(new byte[] {83, 12}, result);
         }
 
-        [Test]
+        [Fact]
         public void CalculateCrcEmpty()
         {
-            Assert.AreEqual(new byte[] {255, 255}, ModbusUtility.CalculateCrc(new byte[] {}));
+            Assert.Equal(new byte[] {255, 255}, ModbusUtility.CalculateCrc(new byte[] {}));
         }
 
-        [Test, ExpectedException(typeof (ArgumentNullException))]
+        [Fact]
         public void CalculateCrcNull()
         {
-            ModbusUtility.CalculateCrc(null);
-            Assert.Fail();
+            Assert.Throws<ArgumentNullException>(() => ModbusUtility.CalculateCrc(null));
         }
 
-        [Test]
+        [Fact]
         public void CalculateLrc()
         {
             ReadCoilsInputsRequest request = new ReadCoilsInputsRequest(Modbus.ReadCoils, 1, 1, 10);
-            Assert.AreEqual(243, ModbusUtility.CalculateLrc(new byte[] {1, 1, 0, 1, 0, 10}));
+            Assert.Equal(243, ModbusUtility.CalculateLrc(new byte[] {1, 1, 0, 1, 0, 10}));
         }
 
-        [Test]
+        [Fact]
         public void CalculateLrc2()
         {
             //: 02 01 0000 0001 FC
             ReadCoilsInputsRequest request = new ReadCoilsInputsRequest(Modbus.ReadCoils, 2, 0, 1);
-            Assert.AreEqual(252, ModbusUtility.CalculateLrc(new byte[] {2, 1, 0, 0, 0, 1}));
+            Assert.Equal(252, ModbusUtility.CalculateLrc(new byte[] {2, 1, 0, 0, 0, 1}));
         }
 
-        [Test, ExpectedException(typeof (ArgumentNullException))]
+        [Fact]
         public void CalculateLrcNull()
         {
-            ModbusUtility.CalculateLrc(null);
-            Assert.Fail();
+            Assert.Throws<ArgumentNullException>(() => ModbusUtility.CalculateLrc(null));
         }
 
-        [Test]
+        [Fact]
         public void CalculateLrcEmpty()
         {
-            Assert.AreEqual(0, ModbusUtility.CalculateLrc(new byte[] {}));
+            Assert.Equal(0, ModbusUtility.CalculateLrc(new byte[] {}));
         }
 
-        [Test]
+        [Fact]
         public void NetworkBytesToHostUInt16()
         {
-            Assert.AreEqual(new ushort[] {1, 2}, ModbusUtility.NetworkBytesToHostUInt16(new byte[] {0, 1, 0, 2}));
+            Assert.Equal(new ushort[] {1, 2}, ModbusUtility.NetworkBytesToHostUInt16(new byte[] { 0, 1, 0, 2 }));
         }
 
-        [Test, ExpectedException(typeof (ArgumentNullException))]
+        [Fact]
         public void NetworkBytesToHostUInt16Null()
         {
-            ModbusUtility.NetworkBytesToHostUInt16(null);
-            Assert.Fail();
+            Assert.Throws<ArgumentNullException>(() => ModbusUtility.NetworkBytesToHostUInt16(null));
         }
 
-        [Test, ExpectedException(typeof (FormatException))]
+        [Fact]
         public void NetworkBytesToHostUInt16OddNumberOfBytes()
         {
-            ModbusUtility.NetworkBytesToHostUInt16(new byte[] {1});
-            Assert.Fail();
+            Assert.Throws<FormatException>(() => ModbusUtility.NetworkBytesToHostUInt16(new byte[] {1}));
         }
 
-        [Test]
+        [Fact]
         public void NetworkBytesToHostUInt16EmptyBytes()
         {
-            Assert.AreEqual(new ushort[] {}, ModbusUtility.NetworkBytesToHostUInt16(new byte[] {}));
+            Assert.Equal(new ushort[] {}, ModbusUtility.NetworkBytesToHostUInt16(new byte[] {}));
         }
 
-        [Test]
+        [Fact]
         public void GetDouble()
         {
-            Assert.AreEqual(0.0, ModbusUtility.GetDouble(0, 0, 0, 0));
-            Assert.AreEqual(1.0, ModbusUtility.GetDouble(16368, 0, 0, 0));
-            Assert.AreEqual(Math.PI, ModbusUtility.GetDouble(16393, 8699, 21572, 11544));
-            Assert.AreEqual(500.625, ModbusUtility.GetDouble(16511, 18944, 0, 0));
+            Assert.Equal(0.0, ModbusUtility.GetDouble(0, 0, 0, 0));
+            Assert.Equal(1.0, ModbusUtility.GetDouble(16368, 0, 0, 0));
+            Assert.Equal(Math.PI, ModbusUtility.GetDouble(16393, 8699, 21572, 11544));
+            Assert.Equal(500.625, ModbusUtility.GetDouble(16511, 18944, 0, 0));
         }
 
-        [Test]
+        [Fact]
         public void GetSingle()
         {
-            Assert.AreEqual(0F, ModbusUtility.GetSingle(0, 0));
-            Assert.AreEqual(1F, ModbusUtility.GetSingle(16256, 0));
-            Assert.AreEqual(9999999F, ModbusUtility.GetSingle(19224, 38527));
-            Assert.AreEqual(500.625F, ModbusUtility.GetSingle(17402, 20480));
+            Assert.Equal(0F, ModbusUtility.GetSingle(0, 0));
+            Assert.Equal(1F, ModbusUtility.GetSingle(16256, 0));
+            Assert.Equal(9999999F, ModbusUtility.GetSingle(19224, 38527));
+            Assert.Equal(500.625F, ModbusUtility.GetSingle(17402, 20480));
         }
 
-        [Test]
+        [Fact]
         public void GetUInt32()
         {
-            Assert.AreEqual(0, ModbusUtility.GetUInt32(0, 0));
-            Assert.AreEqual(1, ModbusUtility.GetUInt32(0, 1));
-            Assert.AreEqual(45, ModbusUtility.GetUInt32(0, 45));
-            Assert.AreEqual(65536, ModbusUtility.GetUInt32(1, 0));
+            Assert.Equal((uint)0, ModbusUtility.GetUInt32(0, 0));
+            Assert.Equal((uint)1, ModbusUtility.GetUInt32(0, 1));
+            Assert.Equal((uint)45, ModbusUtility.GetUInt32(0, 45));
+            Assert.Equal((uint)65536, ModbusUtility.GetUInt32(1, 0));
         }
     }
 }

--- a/NModbus4.UnitTests/app.config
+++ b/NModbus4.UnitTests/app.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-
 <configuration>
     <runtime>
         <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
@@ -14,6 +13,6 @@
         </assemblyBinding>
     </runtime>
     <startup>
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
     </startup>
 </configuration>

--- a/NModbus4.UnitTests/packages.config
+++ b/NModbus4.UnitTests/packages.config
@@ -1,6 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-
 <packages>
-  <package id="NUnit" version="2.6.4" targetFramework="net40" />
-  <package id="RhinoMocks" version="3.6.1" targetFramework="net40" />
+  <package id="RhinoMocks" version="3.6.1" targetFramework="net4" />
+  <package id="xunit" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.assert" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.core" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.extensibility.core" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.runner.visualstudio" version="2.0.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Migrated unit tests to Xunit.  Fixes #15 

* Required upgrading the test project to Framework 4.5 (minimum supported by Xunit).
* Required removing some mock setups which were previously failing, but being hidden by the ExpectedException attribute which is not used in Xunit (fixes #36).