### PR TITLE
Retry receiving response if response is behind request

### DIFF
--- a/NModbus4.UnitTests/IO/ModbusTcpTransportFixture.cs
+++ b/NModbus4.UnitTests/IO/ModbusTcpTransportFixture.cs
@@ -129,6 +129,62 @@ namespace Modbus.UnitTests.IO
         }
 
         [Fact]
+        public void OnShouldRetryResponse_ReturnsTrue_IfWithinThreshold()
+        {
+            ModbusIpTransport transport = new ModbusIpTransport(MockRepository.GenerateStub<IStreamResource>());
+            IModbusMessage request = new ReadCoilsInputsRequest(Modbus.ReadCoils, 1, 1, 1);
+            IModbusMessage response = new ReadCoilsInputsResponse(Modbus.ReadCoils, 1, 1, null);
+
+            request.TransactionId = 5;
+            response.TransactionId = 4;
+            transport.RetryOnOldResponseThreshold = 3;
+
+            Assert.True(transport.OnShouldRetryResponse(request, response));
+        }
+
+        [Fact]
+        public void OnShouldRetryResponse_ReturnsFalse_IfThresholdDisabled()
+        {
+            ModbusIpTransport transport = new ModbusIpTransport(MockRepository.GenerateStub<IStreamResource>());
+            IModbusMessage request = new ReadCoilsInputsRequest(Modbus.ReadCoils, 1, 1, 1);
+            IModbusMessage response = new ReadCoilsInputsResponse(Modbus.ReadCoils, 1, 1, null);
+
+            request.TransactionId = 5;
+            response.TransactionId = 4;
+            transport.RetryOnOldResponseThreshold = 0;
+
+            Assert.False(transport.OnShouldRetryResponse(request, response));
+        }
+
+        [Fact]
+        public void OnShouldRetryResponse_ReturnsFalse_IfEqualTransactionId()
+        {
+            ModbusIpTransport transport = new ModbusIpTransport(MockRepository.GenerateStub<IStreamResource>());
+            IModbusMessage request = new ReadCoilsInputsRequest(Modbus.ReadCoils, 1, 1, 1);
+            IModbusMessage response = new ReadCoilsInputsResponse(Modbus.ReadCoils, 1, 1, null);
+
+            request.TransactionId = 5;
+            response.TransactionId = 5;
+            transport.RetryOnOldResponseThreshold = 3;
+
+            Assert.False(transport.OnShouldRetryResponse(request, response));
+        }
+
+        [Fact]
+        public void OnShouldRetryResponse_ReturnsFalse_IfOutsideThreshold()
+        {
+            ModbusIpTransport transport = new ModbusIpTransport(MockRepository.GenerateStub<IStreamResource>());
+            IModbusMessage request = new ReadCoilsInputsRequest(Modbus.ReadCoils, 1, 1, 1);
+            IModbusMessage response = new ReadCoilsInputsResponse(Modbus.ReadCoils, 1, 1, null);
+
+            request.TransactionId = 5;
+            response.TransactionId = 2;
+            transport.RetryOnOldResponseThreshold = 3;
+
+            Assert.False(transport.OnShouldRetryResponse(request, response));
+        }
+
+        [Fact]
         public void ValidateResponse_MismatchingTransactionIds()
         {
             ModbusIpTransport transport = new ModbusIpTransport(MockRepository.GenerateStub<IStreamResource>());

--- a/NModbus4/IO/ModbusIpTransport.cs
+++ b/NModbus4/IO/ModbusIpTransport.cs
@@ -142,5 +142,16 @@ namespace Modbus.IO
                     "Response was not of expected transaction ID. Expected {0}, received {1}.", request.TransactionId,
                     response.TransactionId));
         }
+
+        internal override bool OnShouldRetryResponse(IModbusMessage request, IModbusMessage response)
+        {
+            if (request.TransactionId > response.TransactionId && request.TransactionId - response.TransactionId < RetryOnOldResponseThreshold)
+            {
+                // This response was from a previous request
+                return true;
+            }
+
+            return base.OnShouldRetryResponse(request, response);
+        }
     }
 }


### PR DESCRIPTION
This introduces the ability for a master to retry receiving a response if the one it picked up was from an earlier request (which timed out according to us).  We use this when communicating with a device which sometimes responds slowly.  Without it, it is possible for a master to be unable to recover - once one response arrives late, there is always one queued until the connection is closed.

The default behaviour is unaffected by this PR (default is off).  To enable it:

    ModbusIpMaster master = ModbusIpMaster.CreateIp(client);
    master.Transport.RetryOnOldResponseThreshold = 3;

Tests have been added to cover the provided functionality.

This is a function I've had in my own fork and been using in production for a couple of years now.