### PR TITLE
Modbus slave network (Multiple slaves on a single physical network)

### DIFF
--- a/NModbus4/Device/ModbusSlave.cs
+++ b/NModbus4/Device/ModbusSlave.cs
@@ -42,7 +42,7 @@
         /// <summary>
         ///     Gets or sets the unit ID.
         /// </summary>
-        public byte UnitId { get; [Obsolete]set; }
+        public byte UnitId { get; set; }
 
         /// <summary>
         ///     Start slave listening for requests.

--- a/NModbus4/Device/ModbusSlave.cs
+++ b/NModbus4/Device/ModbusSlave.cs
@@ -13,7 +13,7 @@
     /// <summary>
     ///     Modbus slave device.
     /// </summary>
-    public abstract class ModbusSlave : ModbusDevice
+    public class ModbusSlave : ModbusDevice
     {
         internal ModbusSlave(byte unitId, ModbusTransport transport)
             : base(transport)
@@ -42,12 +42,25 @@
         /// <summary>
         ///     Gets or sets the unit ID.
         /// </summary>
-        public byte UnitId { get; set; }
+        public byte UnitId { get; [Obsolete]set; }
 
         /// <summary>
         ///     Start slave listening for requests.
         /// </summary>
-        public abstract Task ListenAsync();
+        public virtual Task ListenAsync()
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        ///    Create a slave to be added to a network.
+        /// </summary>
+        /// <param name="unitId"></param>
+        /// <returns></returns>
+        public static ModbusSlave Create(byte unitId)
+        {
+            return new ModbusSlave(unitId, null);
+        }
 
         internal static ReadCoilsInputsResponse ReadDiscretes(
             ReadCoilsInputsRequest request,

--- a/NModbus4/Device/ModbusSlaveNetwork.cs
+++ b/NModbus4/Device/ModbusSlaveNetwork.cs
@@ -1,0 +1,142 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Threading.Tasks;
+using Modbus.IO;
+using Modbus.Message;
+
+namespace Modbus.Device
+{
+    public abstract class ModbusSlaveNetwork : ModbusDevice
+    {
+        private readonly IDictionary<byte, ModbusSlave> _slaves = new ConcurrentDictionary<byte, ModbusSlave>();
+
+        protected ModbusSlaveNetwork(ModbusTransport transport) 
+            : base(transport)
+        {
+        }
+
+        /// <summary>
+        ///     Start slave listening for requests.
+        /// </summary>
+        public abstract Task ListenAsync();
+
+        public Task AddSlaveAsync(ModbusSlave slave)
+        {
+            if (slave == null) throw new ArgumentNullException(nameof(slave));
+
+            _slaves.Add(slave.UnitId, slave);
+
+            return Task.FromResult(0);
+        }
+
+        public Task RemoveSlaveAsync(byte unitId)
+        {
+            _slaves.Remove(unitId);
+
+            return Task.FromResult(0);
+        }
+
+        protected ModbusSlave GetSlave(byte unitId)
+        {
+            ModbusSlave slave;
+
+            _slaves.TryGetValue(unitId, out slave);
+
+            return slave;
+        }
+    }
+
+    public class ModbusSerialSlaveNetwork : ModbusSlaveNetwork
+    {
+        protected ModbusSerialSlaveNetwork(ModbusTransport transport) 
+            : base(transport)
+        {
+        }
+
+        public static ModbusSerialSlaveNetwork CreateRtu(IStreamResource streamResource)
+        {
+            if (streamResource == null)
+            {
+                throw new ArgumentNullException(nameof(streamResource));
+            }
+
+            return new ModbusSerialSlaveNetwork(new ModbusRtuTransport(streamResource));
+        }
+
+        private ModbusSerialTransport SerialTransport
+        {
+            get
+            {
+                var transport = Transport as ModbusSerialTransport;
+
+                if (transport == null)
+                {
+                    throw new ObjectDisposedException("SerialTransport");
+                }
+
+                return transport;
+            }
+        }
+
+        public override async Task ListenAsync()
+        {
+            while (true)
+            {
+                try
+                {
+                    try
+                    {
+                        //TODO: remove deleay once async will be implemented in transport level
+                        await Task.Delay(20).ConfigureAwait(false);
+
+                        // read request and build message
+                        byte[] frame = SerialTransport.ReadRequest();
+                        IModbusMessage request = ModbusMessageFactory.CreateModbusRequest(frame);
+
+                        if (SerialTransport.CheckFrame && !SerialTransport.ChecksumsMatch(request, frame))
+                        {
+                            string msg = $"Checksums failed to match {string.Join(", ", request.MessageFrame)} != {string.Join(", ", frame)}.";
+                            Debug.WriteLine(msg);
+                            throw new IOException(msg);
+                        }
+
+                        ModbusSlave slave = GetSlave(request.SlaveAddress);
+
+                        // only service requests addressed to our slaves
+                        if (slave == null)
+                        {
+                            Debug.WriteLine($"NModbus Slave Network ignoring request intended for NModbus Slave {request.SlaveAddress}");
+                            continue;
+                        }
+
+                        // perform action
+                        IModbusMessage response = slave.ApplyRequest(request);
+
+                        // write response
+                        SerialTransport.Write(response);
+                    }
+                    catch (IOException ioe)
+                    {
+                        Debug.WriteLine($"IO Exception encountered while listening for requests - {ioe.Message}");
+                        SerialTransport.DiscardInBuffer();
+                    }
+                    catch (TimeoutException te)
+                    {
+                        Debug.WriteLine($"Timeout Exception encountered while listening for requests - {te.Message}");
+                        SerialTransport.DiscardInBuffer();
+                    }
+
+                    // TODO better exception handling here, missing FormatException, NotImplemented...
+                }
+                catch (InvalidOperationException)
+                {
+                    // when the underlying transport is disposed
+                    break;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is an attempt to implement multiple Modbus slaves using the same physical connection. These changes doesn't break the existing interface.

https://github.com/NModbus4/NModbus4/issues/118

Approach:
-Added a new abstract class `ModbusSlaveNetwork`, and an implementation: `ModbusSerialSlaveNetwork`.
-`ModbusSlaveNetwork' allows `ModbusSlave` instances to be added / removed.
-Removed `abstract` from `ModbusSlave`. This allows us to take advantage of the existing slave implementation.